### PR TITLE
Disable offline plugin for now while new content is still being added regularly

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,7 +44,7 @@ module.exports = {
         icon: 'src/images/logo.jpg'
       }
     },
-    'gatsby-plugin-offline',
+    // 'gatsby-plugin-offline',
     {
       resolve: 'gatsby-plugin-mailchimp',
       options: {


### PR DESCRIPTION
When you load the site, it checks for a new set of content, if so, refreshes the page with the new cached copies. That can be really not great for new pages since surge gives you a 404.html which is moved to a different url.