### PR TITLE
Add a service worker that removes service workers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,6 +46,7 @@ module.exports = {
       }
     },
     // 'gatsby-plugin-offline',
+    'gatsby-plugin-remove-serviceworker',
     {
       resolve: 'gatsby-plugin-mailchimp',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.44",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "jsesc": "2.5.1",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -69,9 +69,9 @@
       "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -80,7 +80,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -89,9 +89,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -106,7 +106,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -120,7 +120,7 @@
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "lodash": "^4.2.0"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babylon": {
@@ -143,10 +143,10 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "debug": "3.1.0",
+        "globals": "11.5.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babylon": {
@@ -178,9 +178,9 @@
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -216,9 +216,9 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "7.0.59"
       }
     },
     "@types/history": {
@@ -246,7 +246,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.6.tgz",
       "integrity": "sha512-njYCuO//EGrNJ2UAO5LsvQql4zsCP47p3LIb3LmrE9QDRclQdrUCeNo06QsiL0Tkcxm1I7hdF/Q/IdZ2ewDnaA==",
       "requires": {
-        "csstype": "^2.0.0"
+        "csstype": "2.1.1"
       }
     },
     "@types/react-router": {
@@ -254,8 +254,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.23.tgz",
       "integrity": "sha512-o1yEm2Eimw7kwzJSamvBlAPXmhH14zL+AQOCgviGthMcqFVVmhZCv63PgxMZfq+PcfMIqP1O2Wq7BU94IXyVfQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
+        "@types/history": "4.6.2",
+        "@types/react": "16.3.6"
       }
     },
     "@types/react-router-dom": {
@@ -263,9 +263,9 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.2.6.tgz",
       "integrity": "sha512-K7SdbkF8xgecp2WCeXw51IMySYvQ1EuVPKfjU1fymyTSX9bZk5Qx8T5cipwtAY8Zhb/4GIjhYKm0ZGVEbCKEzQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/history": "4.6.2",
+        "@types/react": "16.3.6",
+        "@types/react-router": "4.0.23"
       }
     },
     "@types/tmp": {
@@ -284,7 +284,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -299,7 +299,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       }
     },
     "address": {
@@ -317,10 +317,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -334,9 +334,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alphanum-sort": {
@@ -359,7 +359,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "ansi-escapes": {
@@ -392,8 +392,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "aproba": {
@@ -411,8 +411,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -420,7 +420,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "args": {
@@ -440,7 +440,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -448,9 +448,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -463,7 +463,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -475,7 +475,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
+        "commander": "2.15.1"
       },
       "dependencies": {
         "commander": {
@@ -491,7 +491,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -531,8 +531,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0"
       }
     },
     "array-iterate": {
@@ -561,7 +561,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -599,9 +599,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
@@ -633,7 +633,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.5"
       }
     },
     "async-each": {
@@ -666,12 +666,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
-        "browserslist": "^1.7.6",
-        "caniuse-db": "^1.0.30000634",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.2.16",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000824",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -679,8 +679,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000824",
+            "electron-to-chromium": "1.3.42"
           }
         }
       }
@@ -709,21 +709,21 @@
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.11.0",
-        "convert-source-map": "^1.5.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^4.17.4",
-        "output-file-sync": "^1.1.2",
-        "path-is-absolute": "^1.0.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6",
-        "v8flags": "^2.1.1"
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "commander": {
@@ -738,9 +738,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -748,25 +748,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       }
     },
     "babel-eslint": {
@@ -779,8 +779,8 @@
         "@babel/traverse": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "eslint-scope": "~3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "babylon": {
@@ -796,14 +796,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "babel-helper-bindify-decorators": {
@@ -811,9 +811,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -821,9 +821,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -831,9 +831,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "esutils": "^2.0.2"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -841,10 +841,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -852,10 +852,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -863,9 +863,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -873,10 +873,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -884,11 +884,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -896,8 +896,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -905,8 +905,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -914,8 +914,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -923,9 +923,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -933,11 +933,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -945,12 +945,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -958,8 +958,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-loader": {
@@ -967,10 +967,10 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "requires": {
-        "find-cache-dir": "^0.1.1",
-        "loader-utils": "^0.2.16",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.0.1"
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "babel-messages": {
@@ -978,7 +978,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -991,7 +991,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1070,7 +1070,7 @@
       "integrity": "sha1-Uhx4LTVkRJHJeepoPopeHK/wukI=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-async-generator-functions": {
@@ -1078,9 +1078,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1088,9 +1088,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-cjs-system-wrapper": {
@@ -1099,7 +1099,7 @@
       "integrity": "sha1-vXSUd1KJQk/0k7btRV3klb1xuh0=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -1107,9 +1107,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1117,10 +1117,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1128,11 +1128,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators-legacy": {
@@ -1141,9 +1141,9 @@
       "integrity": "sha512-jYHwjzRXRelYQ1uGm353zNzf3QmtdCfvJbuYTZ4gKveK7M9H1fs3a5AKdY1JUDl0z97E30ukORW1dzhWvsabtA==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-decorators": "^6.1.18",
-        "babel-runtime": "^6.2.0",
-        "babel-template": "^6.3.0"
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -1151,8 +1151,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "requires": {
-        "babel-plugin-syntax-do-expressions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-do-expressions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1160,7 +1160,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1168,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1176,11 +1176,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1188,15 +1188,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1204,8 +1204,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1213,7 +1213,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1221,8 +1221,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1230,7 +1230,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1238,9 +1238,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1248,7 +1248,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1256,9 +1256,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1266,10 +1266,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1277,9 +1277,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1287,9 +1287,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1297,8 +1297,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1306,12 +1306,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1319,8 +1319,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1328,7 +1328,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1336,9 +1336,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1346,7 +1346,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1354,7 +1354,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1362,9 +1362,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-es3-member-expression-literals": {
@@ -1372,7 +1372,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
       "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es3-property-literals": {
@@ -1380,7 +1380,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
       "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1388,9 +1388,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -1398,8 +1398,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1407,8 +1407,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -1416,8 +1416,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "requires": {
-        "babel-plugin-syntax-function-bind": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-function-bind": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-global-system-wrapper": {
@@ -1426,7 +1426,7 @@
       "integrity": "sha1-lI3X0p/CFEfjm9NEfy3rx/L3Oqw=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-object-assign": {
@@ -1434,7 +1434,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
       "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1442,8 +1442,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -1451,7 +1451,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -1459,9 +1459,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "^6.24.1",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-react-jsx": "6.26.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -1469,8 +1469,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -1478,8 +1478,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1487,7 +1487,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1495,8 +1495,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-system-register": {
@@ -1510,9 +1510,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1527,36 +1527,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^2.1.2",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.11.3",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -1564,30 +1564,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-fbjs": {
@@ -1595,34 +1595,34 @@
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
       "integrity": "sha512-6XVQwlO26V5/0P9s2Eje8Epqkv/ihaMJ798+W98ktOA8fCn2IFM6wEi7CDW3fTbKFZ/8fDGvGZH01B6GSuNiWA==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-plugin-syntax-flow": "^6.8.0",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-        "babel-plugin-transform-class-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-        "babel-plugin-transform-es2015-classes": "^6.8.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.8.0",
-        "babel-plugin-transform-es2015-for-of": "^6.8.0",
-        "babel-plugin-transform-es2015-function-name": "^6.8.0",
-        "babel-plugin-transform-es2015-literals": "^6.8.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-        "babel-plugin-transform-es2015-object-super": "^6.8.0",
-        "babel-plugin-transform-es2015-parameters": "^6.8.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.8.0",
-        "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-        "babel-plugin-transform-es3-property-literals": "^6.8.0",
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-plugin-transform-object-rest-spread": "^6.8.0",
-        "babel-plugin-transform-react-display-name": "^6.8.0",
-        "babel-plugin-transform-react-jsx": "^6.8.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es3-member-expression-literals": "6.22.0",
+        "babel-plugin-transform-es3-property-literals": "6.22.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1"
       }
     },
     "babel-preset-flow": {
@@ -1630,7 +1630,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
       }
     },
     "babel-preset-react": {
@@ -1638,12 +1638,12 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.3.13",
-        "babel-plugin-transform-react-display-name": "^6.23.0",
-        "babel-plugin-transform-react-jsx": "^6.24.1",
-        "babel-plugin-transform-react-jsx-self": "^6.22.0",
-        "babel-plugin-transform-react-jsx-source": "^6.22.0",
-        "babel-preset-flow": "^6.23.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-preset-flow": "6.23.0"
       }
     },
     "babel-preset-stage-0": {
@@ -1651,9 +1651,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "requires": {
-        "babel-plugin-transform-do-expressions": "^6.22.0",
-        "babel-plugin-transform-function-bind": "^6.22.0",
-        "babel-preset-stage-1": "^6.24.1"
+        "babel-plugin-transform-do-expressions": "6.22.0",
+        "babel-plugin-transform-function-bind": "6.22.0",
+        "babel-preset-stage-1": "6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1661,9 +1661,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1671,10 +1671,10 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1682,11 +1682,11 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1694,13 +1694,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.5",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1708,8 +1708,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1717,11 +1717,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.5"
       }
     },
     "babel-traverse": {
@@ -1729,15 +1729,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
       }
     },
     "babel-types": {
@@ -1745,10 +1745,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1776,13 +1776,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1790,7 +1790,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1798,7 +1798,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1806,7 +1806,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1814,9 +1814,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1861,13 +1861,13 @@
       "resolved": "https://registry.npmjs.org/bash-glob/-/bash-glob-1.0.2.tgz",
       "integrity": "sha512-E0TTxH9T/tklSXt5R5X0zwxjW56su2VIE+sAruXbd8AtMjYZxtvioybVdptbRk0/0Nvdz0TVVShKhN9sH5dMpg==",
       "requires": {
-        "async-each": "^1.0.1",
-        "bash-path": "^1.0.1",
-        "component-emitter": "^1.2.1",
-        "cross-spawn": "^5.1.0",
-        "extend-shallow": "^2.0.1",
-        "is-extglob": "^2.1.1",
-        "is-glob": "^4.0.0"
+        "async-each": "1.0.1",
+        "bash-path": "1.0.3",
+        "component-emitter": "1.2.1",
+        "cross-spawn": "5.1.0",
+        "extend-shallow": "2.0.1",
+        "is-extglob": "2.1.1",
+        "is-glob": "4.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1875,7 +1875,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-extglob": {
@@ -1888,7 +1888,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -1898,8 +1898,8 @@
       "resolved": "https://registry.npmjs.org/bash-path/-/bash-path-1.0.3.tgz",
       "integrity": "sha512-mGrYvOa6yTY/qNCiZkPFJqWmODK68y6kmVRAJ1NNbWlNoJrUrsFxu7FU2EKg7gbrer6ttrKkF2s/E/lhRy7/OA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "is-windows": "^1.0.1"
+        "arr-union": "3.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "basic-auth": {
@@ -1921,7 +1921,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "better-assert": {
@@ -1937,9 +1937,9 @@
       "resolved": "https://registry.npmjs.org/better-queue/-/better-queue-3.8.7.tgz",
       "integrity": "sha512-OD1yiyXPwIcoicNFeV1hLf4HkmB4V60Pm+hnYsmfY2+HJO5A0nR8vFuJyTjuNxLlGWfv2a4RFq1TRHbxvQNizw==",
       "requires": {
-        "better-queue-memory": "^1.0.1",
-        "node-eta": "^0.9.0",
-        "uuid": "^3.0.0"
+        "better-queue-memory": "1.0.2",
+        "node-eta": "0.9.0",
+        "uuid": "3.2.1"
       }
     },
     "better-queue-memory": {
@@ -1967,8 +1967,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "blob": {
@@ -1997,15 +1997,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "boolbase": {
@@ -2024,7 +2024,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "boxen": {
@@ -2032,13 +2032,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.3.2",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2046,7 +2046,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -2054,9 +2054,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -2069,7 +2069,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2079,7 +2079,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2088,9 +2088,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -2103,12 +2103,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -2116,9 +2116,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -2126,9 +2126,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-rsa": {
@@ -2136,8 +2136,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -2145,13 +2145,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "browserify-zlib": {
@@ -2159,7 +2159,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -2167,8 +2167,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "^1.0.30000792",
-        "electron-to-chromium": "^1.3.30"
+        "caniuse-lite": "1.0.30000824",
+        "electron-to-chromium": "1.3.42"
       }
     },
     "bser": {
@@ -2176,7 +2176,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -2184,9 +2184,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.2.3",
+        "ieee754": "1.1.11",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -2194,8 +2194,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "requires": {
-        "buffer-alloc-unsafe": "^0.1.0",
-        "buffer-fill": "^0.1.0"
+        "buffer-alloc-unsafe": "0.1.1",
+        "buffer-fill": "0.1.1"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2249,15 +2249,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2278,7 +2278,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsite": {
@@ -2302,8 +2302,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2318,10 +2318,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
-        "browserslist": "^1.3.6",
-        "caniuse-db": "^1.0.30000529",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000824",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2329,8 +2329,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000824",
+            "electron-to-chromium": "1.3.42"
           }
         }
       }
@@ -2365,8 +2365,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -2374,11 +2374,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "character-entities": {
@@ -2416,22 +2416,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       },
       "dependencies": {
         "domhandler": {
@@ -2439,7 +2439,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
           "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -2447,12 +2447,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.1",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -2462,15 +2462,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -2483,7 +2483,7 @@
       "resolved": "https://registry.npmjs.org/chunk-manifest-webpack-plugin/-/chunk-manifest-webpack-plugin-0.1.0.tgz",
       "integrity": "sha1-YThIj8Id2rTM+3wcEdUbuAqUMYY=",
       "requires": {
-        "webpack-core": "^0.4.8"
+        "webpack-core": "0.4.8"
       }
     },
     "ci-info": {
@@ -2496,8 +2496,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
@@ -2511,7 +2511,7 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       }
     },
     "class-utils": {
@@ -2519,10 +2519,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2530,7 +2530,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -2550,7 +2550,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2563,8 +2563,8 @@
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
       "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
       "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
+        "arch": "2.1.0",
+        "execa": "0.8.0"
       }
     },
     "cliui": {
@@ -2572,9 +2572,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2582,7 +2582,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -2590,9 +2590,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -2617,7 +2617,7 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -2635,8 +2635,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -2644,9 +2644,9 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.4",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -2654,7 +2654,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -2667,7 +2667,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.3"
       }
     },
     "colormin": {
@@ -2675,9 +2675,9 @@
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "colors": {
@@ -2690,7 +2690,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "comma-separated-tokens": {
@@ -2711,7 +2711,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "common-tags": {
@@ -2719,7 +2719,7 @@
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
       "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "commondir": {
@@ -2747,7 +2747,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "requires": {
-        "mime-db": ">= 1.33.0 < 2"
+        "mime-db": "1.33.0"
       }
     },
     "compression": {
@@ -2755,13 +2755,13 @@
       "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.13",
+        "compressible": "2.0.13",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       }
     },
     "concat-map": {
@@ -2774,10 +2774,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -2785,12 +2785,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.2.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -2803,7 +2803,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -2862,12 +2862,12 @@
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
       "integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
       "requires": {
-        "glob": "^7.0.5",
-        "ltcdr": "^2.2.1",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^0.5.1",
+        "glob": "7.1.2",
+        "ltcdr": "2.2.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "noms": "0.0.0",
-        "through2": "^2.0.1"
+        "through2": "2.0.3"
       }
     },
     "core-js": {
@@ -2885,8 +2885,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-error-class": {
@@ -2894,7 +2894,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -2902,10 +2902,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2913,12 +2913,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -2926,9 +2926,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "cross-env": {
@@ -2936,8 +2936,8 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
       "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
       "requires": {
-        "cross-spawn": "^5.1.0",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "cross-spawn": {
@@ -2945,9 +2945,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypt": {
@@ -2960,7 +2960,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -2968,7 +2968,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -2978,17 +2978,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "crypto-random-string": {
@@ -3002,9 +3002,9 @@
       "integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
       "requires": {
         "balanced-match": "0.1.0",
-        "color": "^0.11.0",
-        "debug": "^3.1.0",
-        "rgb": "~0.1.0"
+        "color": "0.11.4",
+        "debug": "3.1.0",
+        "rgb": "0.1.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -3032,18 +3032,18 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
       "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
       "requires": {
-        "babel-code-frame": "^6.11.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssnano": ">=2.6.1 <4",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.6",
-        "postcss-modules-extract-imports": "^1.0.0",
-        "postcss-modules-local-by-default": "^1.0.1",
-        "postcss-modules-scope": "^1.0.0",
-        "postcss-modules-values": "^1.1.0",
-        "source-list-map": "^0.1.7"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "source-list-map": "0.1.8"
       },
       "dependencies": {
         "loader-utils": {
@@ -3051,9 +3051,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -3063,10 +3063,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-selector-parser": {
@@ -3079,9 +3079,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -3089,9 +3089,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         }
       }
@@ -3111,38 +3111,38 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
-        "autoprefixer": "^6.3.1",
-        "decamelize": "^1.1.2",
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.14",
-        "postcss-calc": "^5.2.0",
-        "postcss-colormin": "^2.1.8",
-        "postcss-convert-values": "^2.3.4",
-        "postcss-discard-comments": "^2.0.4",
-        "postcss-discard-duplicates": "^2.0.1",
-        "postcss-discard-empty": "^2.0.1",
-        "postcss-discard-overridden": "^0.1.1",
-        "postcss-discard-unused": "^2.2.1",
-        "postcss-filter-plugins": "^2.0.0",
-        "postcss-merge-idents": "^2.1.5",
-        "postcss-merge-longhand": "^2.0.1",
-        "postcss-merge-rules": "^2.0.3",
-        "postcss-minify-font-values": "^1.0.2",
-        "postcss-minify-gradients": "^1.0.1",
-        "postcss-minify-params": "^1.0.4",
-        "postcss-minify-selectors": "^2.0.4",
-        "postcss-normalize-charset": "^1.1.0",
-        "postcss-normalize-url": "^3.0.7",
-        "postcss-ordered-values": "^2.1.0",
-        "postcss-reduce-idents": "^2.2.2",
-        "postcss-reduce-initial": "^1.0.0",
-        "postcss-reduce-transforms": "^1.0.3",
-        "postcss-svgo": "^2.1.1",
-        "postcss-unique-selectors": "^2.0.2",
-        "postcss-value-parser": "^3.2.3",
-        "postcss-zindex": "^2.0.1"
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
       }
     },
     "csso": {
@@ -3150,8 +3150,8 @@
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
       }
     },
     "csstype": {
@@ -3164,7 +3164,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -3172,7 +3172,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.42"
       }
     },
     "damerau-levenshtein": {
@@ -3191,7 +3191,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -3233,7 +3233,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "deep-equal": {
@@ -3257,8 +3257,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -3266,8 +3266,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3275,7 +3275,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3283,7 +3283,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3291,9 +3291,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -3318,12 +3318,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3346,8 +3346,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "destroy": {
@@ -3360,7 +3360,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
       "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
       "requires": {
-        "repeat-string": "^1.5.4"
+        "repeat-string": "1.6.1"
       }
     },
     "detect-file": {
@@ -3374,7 +3374,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-libc": {
@@ -3387,8 +3387,8 @@
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.2.tgz",
       "integrity": "sha512-06H99JMCwgbYbA+codm97aBhFLAjABftetp+v+Z88Pvvlkawp2N+1bP/9J24+mihrvk9yBvUYTyIj3NixG1CsA==",
       "requires": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
+        "address": "1.0.3",
+        "debug": "2.6.9"
       }
     },
     "devcert-san": {
@@ -3396,22 +3396,22 @@
       "resolved": "https://registry.npmjs.org/devcert-san/-/devcert-san-0.3.3.tgz",
       "integrity": "sha1-qnckR0Gy2DF3HAEfIu4l45atS6k=",
       "requires": {
-        "@types/configstore": "^2.1.1",
-        "@types/debug": "^0.0.29",
-        "@types/get-port": "^0.0.4",
-        "@types/glob": "^5.0.30",
-        "@types/mkdirp": "^0.3.29",
-        "@types/node": "^7.0.11",
-        "@types/tmp": "^0.0.32",
-        "command-exists": "^1.2.2",
-        "configstore": "^3.0.0",
-        "debug": "^2.6.3",
-        "eol": "^0.8.1",
-        "get-port": "^3.0.0",
-        "glob": "^7.1.1",
-        "mkdirp": "^0.5.1",
-        "tmp": "^0.0.31",
-        "tslib": "^1.6.0"
+        "@types/configstore": "2.1.1",
+        "@types/debug": "0.0.29",
+        "@types/get-port": "0.0.4",
+        "@types/glob": "5.0.35",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "7.0.59",
+        "@types/tmp": "0.0.32",
+        "command-exists": "1.2.2",
+        "configstore": "3.1.2",
+        "debug": "2.6.9",
+        "eol": "0.8.1",
+        "get-port": "3.2.0",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "tmp": "0.0.31",
+        "tslib": "1.9.0"
       }
     },
     "diffie-hellman": {
@@ -3419,9 +3419,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dlv": {
@@ -3436,7 +3436,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-converter": {
@@ -3444,7 +3444,7 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "requires": {
-        "utila": "~0.3"
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -3464,8 +3464,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3480,7 +3480,7 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
-        "urijs": "^1.16.1"
+        "urijs": "1.19.1"
       }
     },
     "dom-walk": {
@@ -3503,7 +3503,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domready": {
@@ -3516,8 +3516,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3525,7 +3525,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotenv": {
@@ -3549,7 +3549,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ee-first": {
@@ -3567,13 +3567,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "email-validator": {
@@ -3601,7 +3601,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
     "end-of-stream": {
@@ -3609,7 +3609,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -3617,12 +3617,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -3638,9 +3638,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -3652,14 +3652,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3676,9 +3676,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -3689,10 +3689,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -3700,9 +3700,9 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.2.0",
-        "tapable": "^0.1.8"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.2.0",
+        "tapable": "0.1.10"
       },
       "dependencies": {
         "memory-fs": {
@@ -3733,7 +3733,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -3741,7 +3741,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -3749,7 +3749,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
       "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
       "requires": {
-        "stackframe": "^1.0.3"
+        "stackframe": "1.0.4"
       }
     },
     "es-abstract": {
@@ -3758,11 +3758,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3771,9 +3771,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -3781,9 +3781,9 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -3791,9 +3791,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-promise": {
@@ -3806,8 +3806,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "es6-template-strings": {
@@ -3816,8 +3816,8 @@
       "integrity": "sha1-sWbGpiVi9Hi7d3X2ypYQOlmbSyw=",
       "optional": true,
       "requires": {
-        "es5-ext": "^0.10.12",
-        "esniff": "^1.1"
+        "es5-ext": "0.10.42",
+        "esniff": "1.1.0"
       }
     },
     "escape-html": {
@@ -3836,44 +3836,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.5.0",
+        "ignore": "3.3.8",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
         "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3888,7 +3888,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3897,9 +3897,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "debug": {
@@ -3935,8 +3935,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -3945,7 +3945,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -3954,7 +3954,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3971,8 +3971,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.7.0"
       }
     },
     "eslint-module-utils": {
@@ -3981,8 +3981,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -3991,16 +3991,16 @@
       "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
       "dev": true,
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.7.0"
       },
       "dependencies": {
         "doctrine": {
@@ -4009,8 +4009,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
@@ -4021,13 +4021,13 @@
       "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
       "dev": true,
       "requires": {
-        "aria-query": "^0.7.0",
-        "array-includes": "^3.0.3",
+        "aria-query": "0.7.1",
+        "array-includes": "3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "^0.1.0",
-        "damerau-levenshtein": "^1.0.0",
-        "emoji-regex": "^6.1.0",
-        "jsx-ast-utils": "^2.0.0"
+        "axobject-query": "0.1.0",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.1.1",
+        "jsx-ast-utils": "2.0.1"
       }
     },
     "eslint-plugin-node": {
@@ -4036,10 +4036,10 @@
       "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
+        "ignore": "3.3.8",
+        "minimatch": "3.0.4",
+        "resolve": "1.7.0",
+        "semver": "5.5.0"
       }
     },
     "eslint-plugin-promise": {
@@ -4054,10 +4054,10 @@
       "integrity": "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.1.0",
-        "has": "^1.0.2",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.1"
+        "doctrine": "2.1.0",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "has": {
@@ -4066,7 +4066,7 @@
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
-            "function-bind": "^1.1.1"
+            "function-bind": "1.1.1"
           }
         },
         "prop-types": {
@@ -4075,9 +4075,9 @@
           "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
           "dev": true,
           "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -4094,8 +4094,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-visitor-keys": {
@@ -4110,8 +4110,8 @@
       "integrity": "sha1-xmhJIp+RRk3t4uDUAgHtar9l8qw=",
       "optional": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.12"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "espree": {
@@ -4120,8 +4120,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.6.2",
+        "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -4143,7 +4143,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -4152,7 +4152,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -4176,7 +4176,7 @@
       "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.2.tgz",
       "integrity": "sha1-n3EDKEwQWmbfQDCysycxZYNwE9o=",
       "requires": {
-        "require-like": ">= 0.1.1"
+        "require-like": "0.1.2"
       }
     },
     "eventemitter3": {
@@ -4194,7 +4194,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -4202,8 +4202,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exec-sh": {
@@ -4212,7 +4212,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "optional": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -4220,13 +4220,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exenv": {
@@ -4244,7 +4244,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -4252,7 +4252,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "expand-template": {
@@ -4265,7 +4265,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "os-homedir": "^1.0.1"
+        "os-homedir": "1.0.2"
       }
     },
     "express": {
@@ -4273,36 +4273,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       }
     },
     "express-graphql": {
@@ -4310,10 +4310,10 @@
       "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.6.12.tgz",
       "integrity": "sha512-ouLWV0hRw4hnaLtXzzwhdC79ewxKbY2PRvm05mPc/zOH5W5WVCHDQ1SmNxEPBQdUeeSNh29aIqW9zEQkA3kMuA==",
       "requires": {
-        "accepts": "^1.3.0",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.3.0",
-        "raw-body": "^2.3.2"
+        "accepts": "1.3.5",
+        "content-type": "1.0.4",
+        "http-errors": "1.6.3",
+        "raw-body": "2.3.2"
       }
     },
     "extend": {
@@ -4326,8 +4326,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4335,7 +4335,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4345,9 +4345,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "tmp": {
@@ -4355,7 +4355,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -4365,7 +4365,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -4373,9 +4373,9 @@
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
       "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
       "requires": {
-        "async": "^1.5.0",
-        "loader-utils": "^0.2.3",
-        "webpack-sources": "^0.1.0"
+        "async": "1.5.2",
+        "loader-utils": "0.2.17",
+        "webpack-sources": "0.1.5"
       },
       "dependencies": {
         "async": {
@@ -4411,10 +4411,10 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-1.0.1.tgz",
       "integrity": "sha512-C2VHbdBwSkaQDyavjQZDflZzmZKrsUK3fTdJtsOnED0L0vtHCw+NL0h8pRcydbpRHlNJLZ4/LbOfEdJKspK91A==",
       "requires": {
-        "bash-glob": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "micromatch": "^3.0.3",
-        "readdir-enhanced": "^1.5.2"
+        "bash-glob": "1.0.2",
+        "glob-parent": "3.1.0",
+        "micromatch": "3.1.10",
+        "readdir-enhanced": "1.5.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -4432,16 +4432,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4449,7 +4449,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4459,13 +4459,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4473,7 +4473,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4481,7 +4481,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -4489,7 +4489,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4497,7 +4497,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4507,7 +4507,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4515,7 +4515,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4525,9 +4525,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4542,14 +4542,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4557,7 +4557,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4565,7 +4565,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4575,10 +4575,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4586,7 +4586,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4596,8 +4596,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -4605,7 +4605,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4613,7 +4613,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4621,9 +4621,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -4636,7 +4636,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4644,7 +4644,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4652,7 +4652,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4672,19 +4672,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4709,24 +4709,24 @@
       "resolved": "https://registry.npmjs.org/favicons/-/favicons-4.8.6.tgz",
       "integrity": "sha1-orE4AKs/7CcVvI8n+oQdA41HYeI=",
       "requires": {
-        "async": "^1.5.0",
-        "cheerio": "^0.19.0",
-        "clone": "^1.0.2",
-        "colors": "^1.1.2",
-        "harmony-reflect": "^1.4.2",
-        "image-size": "^0.4.0",
-        "jimp": "^0.2.13",
+        "async": "1.5.2",
+        "cheerio": "0.19.0",
+        "clone": "1.0.4",
+        "colors": "1.1.2",
+        "harmony-reflect": "1.6.0",
+        "image-size": "0.4.0",
+        "jimp": "0.2.28",
         "jsontoxml": "0.0.11",
-        "merge-defaults": "^0.2.1",
-        "mkdirp": "^0.5.1",
-        "node-rest-client": "^1.5.1",
-        "require-directory": "^2.1.1",
-        "svg2png": "~3.0.1",
-        "through2": "^2.0.0",
-        "tinycolor2": "^1.1.2",
-        "to-ico": "^1.1.2",
-        "underscore": "^1.8.3",
-        "vinyl": "^1.1.0"
+        "merge-defaults": "0.2.1",
+        "mkdirp": "0.5.1",
+        "node-rest-client": "1.8.0",
+        "require-directory": "2.1.1",
+        "svg2png": "3.0.1",
+        "through2": "2.0.3",
+        "tinycolor2": "1.4.1",
+        "to-ico": "1.1.5",
+        "underscore": "1.9.1",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "async": {
@@ -4739,11 +4739,11 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
           "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
           "requires": {
-            "css-select": "~1.0.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "~3.8.1",
-            "lodash": "^3.2.0"
+            "css-select": "1.0.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.8.3",
+            "lodash": "3.10.1"
           }
         },
         "css-select": {
@@ -4751,10 +4751,10 @@
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
           "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
           "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "1.0",
-            "domutils": "1.4",
-            "nth-check": "~1.0.0"
+            "boolbase": "1.0.0",
+            "css-what": "1.0.0",
+            "domutils": "1.4.3",
+            "nth-check": "1.0.1"
           }
         },
         "css-what": {
@@ -4767,7 +4767,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
           "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "domutils": {
@@ -4775,7 +4775,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
           "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -4783,11 +4783,11 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "requires": {
-            "domelementtype": "1",
-            "domhandler": "2.3",
-            "domutils": "1.5",
-            "entities": "1.0",
-            "readable-stream": "1.1"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
           },
           "dependencies": {
             "domutils": {
@@ -4795,8 +4795,8 @@
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
               "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
               }
             },
             "entities": {
@@ -4821,10 +4821,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4839,10 +4839,10 @@
       "resolved": "https://registry.npmjs.org/favicons-webpack-plugin/-/favicons-webpack-plugin-0.0.7.tgz",
       "integrity": "sha1-JTpGpPk9E30QlnYod/io7xLihkg=",
       "requires": {
-        "favicons": "^4.7.1",
-        "loader-utils": "^0.2.14",
-        "lodash": "^4.11.1",
-        "webpack": "^1.13.0"
+        "favicons": "4.8.6",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.5",
+        "webpack": "1.15.0"
       }
     },
     "faye-websocket": {
@@ -4850,7 +4850,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -4858,7 +4858,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbjs": {
@@ -4866,13 +4866,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
       },
       "dependencies": {
         "core-js": {
@@ -4887,7 +4887,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -4895,7 +4895,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4904,8 +4904,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-loader": {
@@ -4913,7 +4913,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
       "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
       "requires": {
-        "loader-utils": "~0.2.5"
+        "loader-utils": "0.2.17"
       }
     },
     "file-type": {
@@ -4936,11 +4936,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -4949,12 +4949,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "find-cache-dir": {
@@ -4962,9 +4962,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "requires": {
-        "commondir": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pkg-dir": "^1.0.0"
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
       }
     },
     "find-node-modules": {
@@ -4973,7 +4973,7 @@
       "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
       "requires": {
         "findup-sync": "0.4.2",
-        "merge": "^1.2.0"
+        "merge": "1.2.0"
       },
       "dependencies": {
         "detect-file": {
@@ -4981,7 +4981,7 @@
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
           "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
           "requires": {
-            "fs-exists-sync": "^0.1.0"
+            "fs-exists-sync": "0.1.0"
           }
         },
         "findup-sync": {
@@ -4989,10 +4989,10 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
           "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
           "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
+            "detect-file": "0.1.0",
+            "is-glob": "2.0.1",
+            "micromatch": "2.3.11",
+            "resolve-dir": "0.1.1"
           }
         },
         "global-modules": {
@@ -5000,8 +5000,8 @@
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
           }
         },
         "global-prefix": {
@@ -5009,10 +5009,10 @@
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.0"
           }
         },
         "is-windows": {
@@ -5025,8 +5025,8 @@
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
           }
         }
       }
@@ -5036,8 +5036,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "path-exists": {
@@ -5045,7 +5045,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -5056,10 +5056,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "optional": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5079,16 +5079,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "optional": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5097,7 +5097,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5108,13 +5108,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "optional": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5123,7 +5123,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "optional": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -5132,7 +5132,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -5141,7 +5141,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "optional": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5150,7 +5150,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "optional": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5161,7 +5161,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "optional": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5170,7 +5170,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "optional": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5181,9 +5181,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "optional": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -5200,14 +5200,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "optional": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5216,7 +5216,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "optional": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -5225,7 +5225,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5236,10 +5236,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "optional": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5248,7 +5248,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5259,7 +5259,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5268,7 +5268,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5277,9 +5277,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "optional": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -5294,7 +5294,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "optional": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -5303,7 +5303,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "optional": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5312,7 +5312,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "optional": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5334,19 +5334,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "optional": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -5357,11 +5357,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "optional": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       },
       "dependencies": {
         "expand-tilde": {
@@ -5370,7 +5370,7 @@
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "optional": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -5386,7 +5386,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
       "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
       "requires": {
-        "is-buffer": "~1.1.2"
+        "is-buffer": "1.1.6"
       }
     },
     "flat-cache": {
@@ -5395,10 +5395,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       },
       "dependencies": {
         "del": {
@@ -5407,13 +5407,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "globby": {
@@ -5422,12 +5422,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -5448,7 +5448,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.3"
       }
     },
     "for-in": {
@@ -5461,7 +5461,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -5479,9 +5479,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
@@ -5494,7 +5494,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -5507,9 +5507,9 @@
       "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz",
       "integrity": "sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==",
       "requires": {
-        "chalk": "^1.1.3",
-        "error-stack-parser": "^2.0.0",
-        "string-width": "^2.0.0"
+        "chalk": "1.1.3",
+        "error-stack-parser": "2.0.1",
+        "string-width": "2.1.1"
       }
     },
     "front-matter": {
@@ -5517,7 +5517,7 @@
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
       "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
       "requires": {
-        "js-yaml": "^3.10.0"
+        "js-yaml": "3.11.0"
       },
       "dependencies": {
         "esprima": {
@@ -5530,8 +5530,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         }
       }
@@ -5551,9 +5551,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs-minipass": {
@@ -5561,7 +5561,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "fs-readdir-recursive": {
@@ -5580,8 +5580,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5603,8 +5603,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -5615,7 +5615,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5669,7 +5669,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -5682,14 +5682,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -5697,12 +5697,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5715,7 +5715,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5723,7 +5723,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5731,8 +5731,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -5748,7 +5748,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5760,7 +5760,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -5771,8 +5771,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -5780,7 +5780,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -5800,9 +5800,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5810,16 +5810,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -5827,8 +5827,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5841,8 +5841,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -5850,10 +5850,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5869,7 +5869,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5887,8 +5887,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5906,10 +5906,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5924,13 +5924,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5938,7 +5938,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -5974,9 +5974,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5984,14 +5984,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -6004,13 +6004,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -6023,7 +6023,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -6052,115 +6052,115 @@
       "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-1.9.250.tgz",
       "integrity": "sha1-4NJb+tapXkcsEJ232g9OOh4cKPQ=",
       "requires": {
-        "async": "^2.1.2",
-        "babel-code-frame": "^6.22.0",
-        "babel-core": "^6.24.1",
-        "babel-loader": "^6.0.0",
-        "babel-plugin-add-module-exports": "^0.2.1",
-        "babel-plugin-transform-object-assign": "^6.8.0",
-        "babel-polyfill": "^6.23.0",
-        "babel-preset-env": "^1.6.0",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-react": "^6.24.1",
-        "babel-preset-stage-0": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.24.1",
-        "babylon": "^6.17.3",
-        "better-queue": "^3.8.6",
-        "bluebird": "^3.5.0",
-        "chalk": "^1.1.3",
-        "chokidar": "^1.7.0",
+        "async": "2.6.0",
+        "babel-code-frame": "6.26.0",
+        "babel-core": "6.26.0",
+        "babel-loader": "6.4.1",
+        "babel-plugin-add-module-exports": "0.2.1",
+        "babel-plugin-transform-object-assign": "6.22.0",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-env": "1.6.1",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-react": "6.24.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "better-queue": "3.8.7",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
         "chunk-manifest-webpack-plugin": "0.1.0",
-        "common-tags": "^1.4.0",
-        "convert-hrtime": "^2.0.0",
-        "copyfiles": "^1.2.0",
-        "core-js": "^2.5.0",
-        "css-loader": "^0.26.1",
-        "debug": "^2.6.0",
-        "del": "^3.0.0",
-        "detect-port": "^1.2.1",
-        "devcert-san": "^0.3.3",
-        "domready": "^1.0.8",
-        "dotenv": "^4.0.0",
-        "express": "^4.14.0",
-        "express-graphql": "^0.6.6",
-        "fast-levenshtein": "~2.0.4",
-        "file-loader": "^0.9.0",
-        "flat": "^2.0.1",
-        "friendly-errors-webpack-plugin": "^1.6.1",
-        "front-matter": "^2.1.0",
-        "fs-extra": "^4.0.1",
-        "gatsby-1-config-css-modules": "^1.0.11",
-        "gatsby-1-config-extract-plugin": "^1.0.3",
-        "gatsby-cli": "^1.1.50",
-        "gatsby-link": "^1.6.40",
-        "gatsby-module-loader": "^1.0.11",
-        "gatsby-react-router-scroll": "^1.0.14",
-        "glob": "^7.1.1",
-        "graphql": "^0.11.7",
-        "graphql-relay": "^0.5.1",
-        "graphql-skip-limit": "^1.0.11",
-        "history": "^4.6.2",
-        "invariant": "^2.2.2",
-        "is-relative": "^0.2.1",
-        "is-relative-url": "^2.0.0",
-        "joi": "12.x.x",
-        "json-loader": "^0.5.2",
-        "json-stringify-safe": "^5.0.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.4",
-        "lodash-id": "^0.14.0",
-        "lowdb": "^0.16.2",
-        "md5": "^2.2.1",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "mitt": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.16.0",
-        "node-libs-browser": "^2.0.0",
-        "normalize-path": "^2.1.1",
-        "null-loader": "^0.1.1",
-        "opn": "^5.1.0",
-        "parse-filepath": "^1.0.1",
-        "path-exists": "^3.0.0",
-        "postcss-browser-reporter": "^0.5.0",
-        "postcss-cssnext": "^2.8.0",
-        "postcss-import": "^8.2.0",
-        "postcss-loader": "^0.13.0",
-        "postcss-reporter": "^1.4.1",
-        "raw-loader": "^0.5.1",
-        "react": "^15.6.0",
-        "react-dev-utils": "^4.2.1",
-        "react-dom": "^15.6.0",
-        "react-error-overlay": "^3.0.0",
-        "react-hot-loader": "^3.0.0-beta.6",
-        "react-router": "^4.1.1",
-        "react-router-dom": "^4.1.1",
-        "redux": "^3.6.0",
+        "common-tags": "1.7.2",
+        "convert-hrtime": "2.0.0",
+        "copyfiles": "1.2.0",
+        "core-js": "2.5.5",
+        "css-loader": "0.26.4",
+        "debug": "2.6.9",
+        "del": "3.0.0",
+        "detect-port": "1.2.2",
+        "devcert-san": "0.3.3",
+        "domready": "1.0.8",
+        "dotenv": "4.0.0",
+        "express": "4.16.3",
+        "express-graphql": "0.6.12",
+        "fast-levenshtein": "2.0.6",
+        "file-loader": "0.9.0",
+        "flat": "2.0.1",
+        "friendly-errors-webpack-plugin": "1.7.0",
+        "front-matter": "2.3.0",
+        "fs-extra": "4.0.3",
+        "gatsby-1-config-css-modules": "1.0.11",
+        "gatsby-1-config-extract-plugin": "1.0.3",
+        "gatsby-cli": "1.1.50",
+        "gatsby-link": "1.6.40",
+        "gatsby-module-loader": "1.0.11",
+        "gatsby-react-router-scroll": "1.0.14",
+        "glob": "7.1.2",
+        "graphql": "0.11.7",
+        "graphql-relay": "0.5.5",
+        "graphql-skip-limit": "1.0.11",
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "is-relative": "0.2.1",
+        "is-relative-url": "2.0.0",
+        "joi": "12.0.0",
+        "json-loader": "0.5.7",
+        "json-stringify-safe": "5.0.1",
+        "json5": "0.5.1",
+        "lodash": "4.17.5",
+        "lodash-id": "0.14.0",
+        "lowdb": "0.16.2",
+        "md5": "2.2.1",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "mitt": "1.1.3",
+        "mkdirp": "0.5.1",
+        "moment": "2.22.0",
+        "node-libs-browser": "2.1.0",
+        "normalize-path": "2.1.1",
+        "null-loader": "0.1.1",
+        "opn": "5.3.0",
+        "parse-filepath": "1.0.2",
+        "path-exists": "3.0.0",
+        "postcss-browser-reporter": "0.5.0",
+        "postcss-cssnext": "2.11.0",
+        "postcss-import": "8.2.0",
+        "postcss-loader": "0.13.0",
+        "postcss-reporter": "1.4.1",
+        "raw-loader": "0.5.1",
+        "react": "15.6.2",
+        "react-dev-utils": "4.2.1",
+        "react-dom": "15.6.2",
+        "react-error-overlay": "3.0.0",
+        "react-hot-loader": "3.1.3",
+        "react-router": "4.2.0",
+        "react-router-dom": "4.2.2",
+        "redux": "3.7.2",
         "relay-compiler": "1.4.1",
-        "remote-redux-devtools": "^0.5.7",
-        "serve": "^6.4.0",
-        "shallow-compare": "^1.2.2",
-        "sift": "^3.2.6",
-        "signal-exit": "^3.0.2",
-        "slash": "^1.0.0",
-        "socket.io": "^2.0.3",
-        "static-site-generator-webpack-plugin": "^3.4.1",
-        "string-similarity": "^1.2.0",
-        "style-loader": "^0.13.0",
-        "type-of": "^2.0.1",
-        "url-loader": "^0.5.7",
-        "uuid": "^3.1.0",
-        "v8-compile-cache": "^1.1.0",
-        "webpack": "^1.13.3",
-        "webpack-configurator": "^0.3.0",
-        "webpack-dev-middleware": "^1.8.4",
-        "webpack-dev-server": "^1.16.1",
-        "webpack-hot-middleware": "^2.13.2",
+        "remote-redux-devtools": "0.5.12",
+        "serve": "6.5.4",
+        "shallow-compare": "1.2.2",
+        "sift": "3.3.12",
+        "signal-exit": "3.0.2",
+        "slash": "1.0.0",
+        "socket.io": "2.1.0",
+        "static-site-generator-webpack-plugin": "3.4.1",
+        "string-similarity": "1.2.0",
+        "style-loader": "0.13.2",
+        "type-of": "2.0.1",
+        "url-loader": "0.5.9",
+        "uuid": "3.2.1",
+        "v8-compile-cache": "1.1.2",
+        "webpack": "1.15.0",
+        "webpack-configurator": "0.3.1",
+        "webpack-dev-middleware": "1.12.2",
+        "webpack-dev-server": "1.16.5",
+        "webpack-hot-middleware": "2.22.0",
         "webpack-md5-hash": "0.0.5",
-        "webpack-stats-plugin": "^0.1.4",
-        "webpack-validator": "^2.2.7",
-        "yaml-loader": "^0.4.0"
+        "webpack-stats-plugin": "0.1.5",
+        "webpack-validator": "2.3.0",
+        "yaml-loader": "0.4.0"
       },
       "dependencies": {
         "gatsby-cli": {
@@ -6168,23 +6168,23 @@
           "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-1.1.50.tgz",
           "integrity": "sha1-iLke3NeYZufaxjXK0ypDodhkny8=",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "bluebird": "^3.5.0",
-            "common-tags": "^1.4.0",
-            "convert-hrtime": "^2.0.0",
-            "core-js": "^2.5.0",
-            "execa": "^0.8.0",
-            "fs-extra": "^4.0.1",
-            "hosted-git-info": "^2.5.0",
-            "lodash": "^4.17.4",
-            "pretty-error": "^2.1.1",
-            "resolve-cwd": "^2.0.0",
-            "source-map": "^0.5.7",
-            "stack-trace": "^0.0.10",
-            "update-notifier": "^2.3.0",
-            "yargs": "^8.0.2",
-            "yurnalist": "^0.2.1"
+            "babel-code-frame": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "bluebird": "3.5.1",
+            "common-tags": "1.7.2",
+            "convert-hrtime": "2.0.0",
+            "core-js": "2.5.5",
+            "execa": "0.8.0",
+            "fs-extra": "4.0.3",
+            "hosted-git-info": "2.6.0",
+            "lodash": "4.17.5",
+            "pretty-error": "2.1.1",
+            "resolve-cwd": "2.0.0",
+            "source-map": "0.5.7",
+            "stack-trace": "0.0.10",
+            "update-notifier": "2.4.0",
+            "yargs": "8.0.2",
+            "yurnalist": "0.2.1"
           }
         }
       }
@@ -6194,7 +6194,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-css-modules/-/gatsby-1-config-css-modules-1.0.11.tgz",
       "integrity": "sha1-WhAsaxH5ppY7OJLsyVlRHhaI5SU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-1-config-extract-plugin": {
@@ -6202,8 +6202,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-extract-plugin/-/gatsby-1-config-extract-plugin-1.0.3.tgz",
       "integrity": "sha1-niyWLUVjyV+inag+PZMBcSmvARU=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "extract-text-webpack-plugin": "^1.0.1"
+        "babel-runtime": "6.26.0",
+        "extract-text-webpack-plugin": "1.0.1"
       }
     },
     "gatsby-link": {
@@ -6211,11 +6211,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-1.6.40.tgz",
       "integrity": "sha1-5gqys2RSx0ePE1mn8D9+D8Nc2Ec=",
       "requires": {
-        "@types/history": "^4.6.2",
-        "@types/react-router-dom": "^4.2.2",
-        "babel-runtime": "^6.26.0",
-        "prop-types": "^15.5.8",
-        "ric": "^1.3.0"
+        "@types/history": "4.6.2",
+        "@types/react-router-dom": "4.2.6",
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.0",
+        "ric": "1.3.0"
       }
     },
     "gatsby-module-loader": {
@@ -6223,8 +6223,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-module-loader/-/gatsby-module-loader-1.0.11.tgz",
       "integrity": "sha1-NfJpRW9qbYXGk73Cs7OzQymH9Vs=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "loader-utils": "^0.2.16"
+        "babel-runtime": "6.26.0",
+        "loader-utils": "0.2.17"
       }
     },
     "gatsby-plugin-favicon": {
@@ -6232,7 +6232,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-favicon/-/gatsby-plugin-favicon-2.1.1.tgz",
       "integrity": "sha512-B3Auj7H749iwJZIV15yXmyWTo+M7RoXzVU5B/Ghdd9roSII0bftpeiQJlQjripRQAOcVw5QKGHt4WUr3zdBrWw==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "babel-runtime": "6.26.0",
         "favicons-webpack-plugin": "0.0.7"
       }
     },
@@ -6241,7 +6241,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-1.0.31.tgz",
       "integrity": "sha1-6vFuGAlGGxC63xLAUDjEKXRXg8A=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-plugin-mailchimp": {
@@ -6249,8 +6249,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-mailchimp/-/gatsby-plugin-mailchimp-2.2.3.tgz",
       "integrity": "sha1-78E77X/b9uX67/IkKpAtRPoNwyw=",
       "requires": {
-        "email-validator": "^2.0.3",
-        "jsonp": "^0.2.1"
+        "email-validator": "2.0.4",
+        "jsonp": "0.2.1"
       }
     },
     "gatsby-plugin-manifest": {
@@ -6258,9 +6258,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-1.0.25.tgz",
       "integrity": "sha1-OHniKtl5EAk1axxGUGXA0CYYleU=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "sharp": "^0.20.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "sharp": "0.20.3"
       }
     },
     "gatsby-plugin-offline": {
@@ -6268,8 +6268,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-1.0.18.tgz",
       "integrity": "sha1-LuKiTS9p/MQ6AVEy8HFBtpKVMY0=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "sw-precache": "^5.0.0"
+        "babel-runtime": "6.26.0",
+        "sw-precache": "5.2.1"
       }
     },
     "gatsby-plugin-react-helmet": {
@@ -6277,15 +6277,20 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.10.tgz",
       "integrity": "sha1-jt20DruwPzNMEZ9AESsCAyVwZzU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
+    },
+    "gatsby-plugin-remove-serviceworker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz",
+      "integrity": "sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w="
     },
     "gatsby-plugin-twitter": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-1.0.20.tgz",
       "integrity": "sha1-1phTlaUceAOh+zXp7wUHmFUcvqU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-react-router-scroll": {
@@ -6293,9 +6298,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.14.tgz",
       "integrity": "sha1-fjtZwiZncgMMa/6qiRTHHdPBLFk=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "scroll-behavior": "^0.9.9",
-        "warning": "^3.0.0"
+        "babel-runtime": "6.26.0",
+        "scroll-behavior": "0.9.9",
+        "warning": "3.0.0"
       }
     },
     "gatsby-source-filesystem": {
@@ -6303,18 +6308,18 @@
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-1.5.38.tgz",
       "integrity": "sha1-m/dMe6soD1UrB0xyr/mfe8pF+Sc=",
       "requires": {
-        "babel-cli": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "better-queue": "^3.8.7",
-        "bluebird": "^3.5.0",
-        "chokidar": "^1.7.0",
-        "fs-extra": "^4.0.1",
-        "got": "^7.1.0",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "pretty-bytes": "^4.0.2",
-        "slash": "^1.0.0",
-        "valid-url": "^1.0.9"
+        "babel-cli": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "better-queue": "3.8.7",
+        "bluebird": "3.5.1",
+        "chokidar": "1.7.0",
+        "fs-extra": "4.0.3",
+        "got": "7.1.0",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "pretty-bytes": "4.0.2",
+        "slash": "1.0.0",
+        "valid-url": "1.0.9"
       },
       "dependencies": {
         "got": {
@@ -6322,20 +6327,20 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         }
       }
@@ -6345,26 +6350,26 @@
       "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-1.7.41.tgz",
       "integrity": "sha1-v94pKgZdMGwk5dMD7CjqJHhvCW4=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "graphql-type-json": "^0.1.4",
-        "gray-matter": "^3.0.0",
-        "hast-util-raw": "^2.0.2",
-        "hast-util-to-html": "^3.0.0",
-        "lodash": "^4.17.4",
-        "mdast-util-to-hast": "^2.4.0",
-        "mdast-util-toc": "^2.0.1",
-        "remark": "^7.0.1",
-        "remark-parse": "^4.0.0",
-        "remark-retext": "^3.1.0",
-        "remark-stringify": "^4.0.0",
-        "retext-english": "^3.0.0",
-        "sanitize-html": "^1.14.1",
-        "underscore.string": "^3.3.4",
-        "unified": "^6.1.5",
-        "unist-util-remove-position": "^1.1.1",
-        "unist-util-select": "^1.5.0",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "graphql-type-json": "0.1.4",
+        "gray-matter": "3.1.1",
+        "hast-util-raw": "2.0.2",
+        "hast-util-to-html": "3.1.0",
+        "lodash": "4.17.5",
+        "mdast-util-to-hast": "2.5.0",
+        "mdast-util-toc": "2.0.1",
+        "remark": "7.0.1",
+        "remark-parse": "4.0.0",
+        "remark-retext": "3.1.0",
+        "remark-stringify": "4.0.0",
+        "retext-english": "3.0.0",
+        "sanitize-html": "1.18.2",
+        "underscore.string": "3.3.4",
+        "unified": "6.2.0",
+        "unist-util-remove-position": "1.1.2",
+        "unist-util-select": "1.5.0",
+        "unist-util-visit": "1.3.1"
       }
     },
     "gauge": {
@@ -6372,11 +6377,11 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
+        "ansi": "0.3.1",
+        "has-unicode": "2.0.1",
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
       }
     },
     "get-caller-file": {
@@ -6414,7 +6419,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "github-from-package": {
@@ -6427,7 +6432,7 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
       "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
       "requires": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
+        "emoji-regex": "6.1.1"
       }
     },
     "glob": {
@@ -6435,12 +6440,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -6448,8 +6453,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -6457,7 +6462,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-to-regexp": {
@@ -6470,8 +6475,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       },
       "dependencies": {
         "process": {
@@ -6486,7 +6491,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -6494,9 +6499,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -6504,11 +6509,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -6516,7 +6521,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -6531,11 +6536,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -6550,17 +6555,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -6591,8 +6596,8 @@
       "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-1.0.11.tgz",
       "integrity": "sha1-xpcNEb3+eqAB+WyLpBuak6bcgFw=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "graphql": "^0.11.7"
+        "babel-runtime": "6.26.0",
+        "graphql": "0.11.7"
       }
     },
     "graphql-type-json": {
@@ -6605,10 +6610,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.10.0",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.12.0",
+        "kind-of": "5.1.0",
+        "strip-bom-string": "1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -6621,7 +6626,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "js-yaml": {
@@ -6629,8 +6634,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "kind-of": {
@@ -6645,7 +6650,7 @@
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "requires": {
-        "duplexer": "^0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "handlebars": {
@@ -6653,10 +6658,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -6669,7 +6674,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -6684,8 +6689,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "harmony-reflect": {
@@ -6698,7 +6703,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -6706,7 +6711,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -6744,7 +6749,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -6757,9 +6762,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6774,8 +6779,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6783,7 +6788,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6791,7 +6796,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6801,7 +6806,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6811,7 +6816,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "hash.js": {
@@ -6819,8 +6824,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "hasha": {
@@ -6828,8 +6833,8 @@
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hast-to-hyperscript": {
@@ -6837,13 +6842,13 @@
       "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-3.1.0.tgz",
       "integrity": "sha512-/At2y6sQLTAcL6y+3hRQFcaBoRlKrmHSpvvdOZqRz6uI2YyjrU8rJ7e1LbmLtWUmzaIqKEdNSku+AJC0pt4+aw==",
       "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "is-nan": "^1.2.1",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "is-nan": "1.2.1",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
         "trim": "0.0.1",
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "hast-util-from-parse5": {
@@ -6851,10 +6856,10 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-2.1.0.tgz",
       "integrity": "sha1-9hI9g9NoljCwl+E+Qw0W2dG9iIQ=",
       "requires": {
-        "camelcase": "^3.0.0",
-        "hastscript": "^3.0.0",
-        "property-information": "^3.1.0",
-        "vfile-location": "^2.0.0"
+        "camelcase": "3.0.0",
+        "hastscript": "3.1.0",
+        "property-information": "3.2.0",
+        "vfile-location": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -6879,13 +6884,13 @@
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-2.0.2.tgz",
       "integrity": "sha512-ujytXSAZC85bvh38f8ALzfE2IZDdCwB9XeHUs9l20C1p4/1YeAoZqq9z9U17vWQ9hMmqbVaROuSK8feL3wTCJg==",
       "requires": {
-        "hast-util-from-parse5": "^2.0.0",
-        "hast-util-to-parse5": "^2.0.0",
-        "html-void-elements": "^1.0.1",
-        "parse5": "^3.0.3",
-        "unist-util-position": "^3.0.0",
-        "web-namespaces": "^1.0.0",
-        "zwitch": "^1.0.0"
+        "hast-util-from-parse5": "2.1.0",
+        "hast-util-to-parse5": "2.2.0",
+        "html-void-elements": "1.0.3",
+        "parse5": "3.0.3",
+        "unist-util-position": "3.0.1",
+        "web-namespaces": "1.1.2",
+        "zwitch": "1.0.3"
       }
     },
     "hast-util-to-html": {
@@ -6893,17 +6898,17 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
       "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
       "requires": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.1.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-is-element": "1.0.0",
+        "hast-util-whitespace": "1.0.0",
+        "html-void-elements": "1.0.3",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
+        "stringify-entities": "1.3.2",
+        "unist-util-is": "2.1.2",
+        "xtend": "4.0.1"
       }
     },
     "hast-util-to-parse5": {
@@ -6911,11 +6916,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-2.2.0.tgz",
       "integrity": "sha512-Eg1mrf0VTT/PipFN5z1+mVi+4GNhinKk/i/HKeX1h17IYiMdm3G8vgA0FU04XCuD1cWV58f5zziFKcBkr+WuKw==",
       "requires": {
-        "hast-to-hyperscript": "^3.0.0",
-        "mapz": "^1.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
-        "zwitch": "^1.0.0"
+        "hast-to-hyperscript": "3.1.0",
+        "mapz": "1.0.2",
+        "web-namespaces": "1.1.2",
+        "xtend": "4.0.1",
+        "zwitch": "1.0.3"
       }
     },
     "hast-util-whitespace": {
@@ -6928,11 +6933,11 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-3.1.0.tgz",
       "integrity": "sha512-8V34dMSDT1Ik+ZSgTzCLdyp89MrWxcxctXPxhmb72GQj1Xkw1aHPM9UaHCWewvH2Q+PVkYUm4ZJVw4T0dgEGNA==",
       "requires": {
-        "camelcase": "^3.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0"
+        "camelcase": "3.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-parse-selector": "2.1.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2"
       },
       "dependencies": {
         "camelcase": {
@@ -6947,10 +6952,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "history": {
@@ -6958,11 +6963,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
       }
     },
     "hmac-drbg": {
@@ -6970,9 +6975,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -6990,8 +6995,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -6999,7 +7004,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -7027,10 +7032,10 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -7038,7 +7043,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "isarray": {
@@ -7051,10 +7056,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -7069,10 +7074,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -7085,8 +7090,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -7094,10 +7099,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.5",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -7110,7 +7115,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -7120,9 +7125,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -7176,7 +7181,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -7194,8 +7199,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -7213,20 +7218,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7239,7 +7244,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7247,9 +7252,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -7262,7 +7267,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -7270,7 +7275,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7285,7 +7290,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -7313,8 +7318,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       },
       "dependencies": {
         "is-relative": {
@@ -7322,7 +7327,7 @@
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
           "requires": {
-            "is-unc-path": "^1.0.0"
+            "is-unc-path": "1.0.0"
           }
         },
         "is-unc-path": {
@@ -7330,7 +7335,7 @@
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
           "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
           "requires": {
-            "unc-path-regex": "^0.1.2"
+            "unc-path-regex": "0.1.2"
           }
         }
       }
@@ -7345,7 +7350,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-alphabetical": {
@@ -7363,8 +7368,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-arrayish": {
@@ -7377,7 +7382,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -7390,7 +7395,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -7403,7 +7408,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -7411,7 +7416,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-date-object": {
@@ -7430,9 +7435,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7452,7 +7457,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -7470,7 +7475,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -7488,7 +7493,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hexadecimal": {
@@ -7501,8 +7506,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-nan": {
@@ -7510,7 +7515,7 @@
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
       "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
       "requires": {
-        "define-properties": "^1.1.1"
+        "define-properties": "1.1.2"
       }
     },
     "is-npm": {
@@ -7523,7 +7528,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -7541,7 +7546,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7561,7 +7566,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -7569,7 +7574,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -7582,7 +7587,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7618,7 +7623,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-relative": {
@@ -7626,7 +7631,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "^0.1.1"
+        "is-unc-path": "0.1.2"
       }
     },
     "is-relative-url": {
@@ -7634,7 +7639,7 @@
       "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
       "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
       "requires": {
-        "is-absolute-url": "^2.0.0"
+        "is-absolute-url": "2.1.0"
       }
     },
     "is-resolvable": {
@@ -7663,7 +7668,7 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -7682,7 +7687,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "requires": {
-        "unc-path-regex": "^0.1.0"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -7720,7 +7725,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.0"
       }
     },
     "isexe": {
@@ -7746,8 +7751,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -7760,8 +7765,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "items": {
@@ -7779,22 +7784,22 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "bignumber.js": "^2.1.0",
+        "bignumber.js": "2.4.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "^3.0.2",
-        "exif-parser": "^0.1.9",
-        "file-type": "^3.1.0",
-        "jpeg-js": "^0.2.0",
-        "load-bmfont": "^1.2.3",
-        "mime": "^1.3.4",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.6.0",
         "mkdirp": "0.5.1",
-        "pixelmatch": "^4.0.0",
-        "pngjs": "^3.0.0",
-        "read-chunk": "^1.0.1",
-        "request": "^2.65.0",
-        "stream-to-buffer": "^0.1.0",
-        "tinycolor2": "^1.1.2",
-        "url-regex": "^3.0.0"
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.3",
+        "read-chunk": "1.0.1",
+        "request": "2.85.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -7809,9 +7814,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
       "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
       "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
+        "hoek": "4.2.1",
+        "isemail": "3.1.2",
+        "topo": "2.0.2"
       }
     },
     "jpeg-js": {
@@ -7834,8 +7839,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "jsan": {
@@ -7895,7 +7900,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -7908,7 +7913,7 @@
       "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
       "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
       "requires": {
-        "debug": "^2.1.3"
+        "debug": "2.6.9"
       }
     },
     "jsontoxml": {
@@ -7922,27 +7927,27 @@
       "integrity": "sha512-fqO8V3/V2j9zqDHg6msMvRj/yr5T8WSEO5w/2PrgGC3noKuh4Mg/W6Tp+jOAbDl/t0jHQVLHfVBEA128EYhkug==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "chalk": "^1.1.1",
-        "core-js": "^1.2.6",
-        "glob": "^6.0.1",
-        "graceful-fs": "^4.1.2",
-        "jspm-github": "^0.14.11",
-        "jspm-npm": "^0.30.3",
-        "jspm-registry": "^0.4.1",
-        "liftoff": "^2.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "ncp": "^2.0.0",
-        "proper-lockfile": "^1.1.2",
-        "request": "^2.67.0",
-        "rimraf": "^2.4.4",
-        "sane": "^1.3.3",
-        "semver": "^5.1.0",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "core-js": "1.2.7",
+        "glob": "6.0.4",
+        "graceful-fs": "4.1.11",
+        "jspm-github": "0.14.13",
+        "jspm-npm": "0.30.4",
+        "jspm-registry": "0.4.4",
+        "liftoff": "2.5.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "proper-lockfile": "1.2.0",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "sane": "1.7.0",
+        "semver": "5.5.0",
         "systemjs": "0.20.19",
         "systemjs-builder": "0.16.12",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "core-js": {
@@ -7957,11 +7962,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "optional": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -7972,16 +7977,16 @@
       "integrity": "sha1-Mm5SF9NjmyFgkpOwHn4Yd13T3Mc=",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "expand-tilde": "^1.2.0",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "netrc": "^0.1.3",
-        "request": "^2.74.0",
-        "rimraf": "^2.5.4",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
-        "which": "^1.0.9"
+        "bluebird": "3.5.1",
+        "expand-tilde": "1.2.2",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "netrc": "0.1.4",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.0",
+        "which": "1.3.0"
       }
     },
     "jspm-npm": {
@@ -7990,16 +7995,16 @@
       "integrity": "sha512-Gx9/HGtbV4igvvAzhI8rGSzUIUIZtIK5kA7yf+5dGqmbD6hUUK29OxhbF7y/xXmpqyJ7iwiEY5vIszT5rPaz+A==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "buffer-peek-stream": "^1.0.1",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "readdirp": "^2.0.0",
-        "request": "^2.58.0",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
+        "bluebird": "3.5.1",
+        "buffer-peek-stream": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "readdirp": "2.1.0",
+        "request": "2.85.0",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.0",
         "traceur": "0.0.105",
-        "which": "^1.1.1"
+        "which": "1.3.0"
       }
     },
     "jspm-registry": {
@@ -8008,10 +8013,10 @@
       "integrity": "sha1-1TFmA1qHzc5YXWK6o5dWhUaZbXA=",
       "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "rimraf": "^2.3.2",
-        "rsvp": "^3.0.18",
-        "semver": "^4.3.3"
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6"
       },
       "dependencies": {
         "semver": {
@@ -8039,7 +8044,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "3.0.3"
       }
     },
     "kebab-case": {
@@ -8057,7 +8062,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -8065,7 +8070,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "latest-version": {
@@ -8073,7 +8078,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -8086,7 +8091,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "leven": {
@@ -8100,8 +8105,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -8110,14 +8115,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.7.0"
       }
     },
     "linked-list": {
@@ -8131,12 +8136,12 @@
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.0",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
+        "mime": "1.6.0",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.5.0",
+        "xtend": "4.0.1"
       }
     },
     "load-json-file": {
@@ -8144,10 +8149,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8162,10 +8167,10 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "locate-path": {
@@ -8173,8 +8178,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -8317,8 +8322,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -8326,7 +8331,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lodash.toarray": {
@@ -8350,7 +8355,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "loglevel": {
@@ -8365,8 +8370,8 @@
       "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "loglevel": "^1.4.1"
+        "chalk": "1.1.3",
+        "loglevel": "1.6.1"
       }
     },
     "longest": {
@@ -8384,7 +8389,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -8392,8 +8397,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowdb": {
@@ -8401,10 +8406,10 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.16.2.tgz",
       "integrity": "sha1-oql262bsV3lykZcPPIfNthEm+jo=",
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "steno": "^0.4.1"
+        "graceful-fs": "4.1.11",
+        "is-promise": "2.1.0",
+        "lodash": "4.17.5",
+        "steno": "0.4.4"
       }
     },
     "lowercase-keys": {
@@ -8417,8 +8422,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "ltcdr": {
@@ -8436,7 +8441,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-iterator": {
@@ -8445,7 +8450,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "optional": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8462,7 +8467,7 @@
       "integrity": "sha512-zhDAr/erfvZtE1A66DIQ7ZNdGlexVGNDP1P1kvLZprRE0meA0zmxNbp6xmXzNRuZmgW0Ui4ibbaMPYPFHVRMkQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -8480,7 +8485,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "optional": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-cache": {
@@ -8498,7 +8503,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mapz": {
@@ -8506,7 +8511,7 @@
       "resolved": "https://registry.npmjs.org/mapz/-/mapz-1.0.2.tgz",
       "integrity": "sha512-NuY43BoHy5K4jVg3/oD+g8ysNwdXY3HB5UankVWoikxT9YMqgCYC77pNRENTm/DfslLxPFEOyJUw9h9isRty6w==",
       "requires": {
-        "x-is-array": "^0.1.0"
+        "x-is-array": "0.1.0"
       }
     },
     "markdown-escapes": {
@@ -8529,9 +8534,9 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
       }
     },
     "md5-file": {
@@ -8539,7 +8544,7 @@
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
       "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
       "requires": {
-        "buffer-alloc": "^1.1.0"
+        "buffer-alloc": "1.1.0"
       }
     },
     "md5.js": {
@@ -8547,8 +8552,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       },
       "dependencies": {
         "hash-base": {
@@ -8556,8 +8561,8 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -8567,8 +8572,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdast-util-definitions": {
@@ -8576,7 +8581,7 @@
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
       "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
       "requires": {
-        "unist-util-visit": "^1.0.0"
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdast-util-to-hast": {
@@ -8584,17 +8589,17 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
       "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
+        "collapse-white-space": "1.0.4",
+        "detab": "2.0.1",
+        "mdast-util-definitions": "1.2.2",
+        "mdurl": "1.0.1",
         "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
+        "trim-lines": "1.1.1",
+        "unist-builder": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1",
+        "xtend": "4.0.1"
       }
     },
     "mdast-util-to-nlcst": {
@@ -8602,10 +8607,10 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.0.tgz",
       "integrity": "sha1-2tJihXZY0eq0tYFKIOL5PXyh47Y=",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "repeat-string": "^1.5.2",
-        "unist-util-position": "^3.0.0",
-        "vfile-location": "^2.0.0"
+        "nlcst-to-string": "2.0.2",
+        "repeat-string": "1.6.1",
+        "unist-util-position": "3.0.1",
+        "vfile-location": "2.0.3"
       }
     },
     "mdast-util-to-string": {
@@ -8618,9 +8623,9 @@
       "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-2.0.1.tgz",
       "integrity": "sha1-sdLLI7+wH4Evp7Vb/+iwqL7fbyE=",
       "requires": {
-        "github-slugger": "^1.1.1",
-        "mdast-util-to-string": "^1.0.2",
-        "unist-util-visit": "^1.1.0"
+        "github-slugger": "1.2.0",
+        "mdast-util-to-string": "1.0.4",
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdurl": {
@@ -8638,7 +8643,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -8646,8 +8651,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -8655,16 +8660,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -8672,11 +8677,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "minimist": {
@@ -8689,9 +8694,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -8704,9 +8709,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -8714,8 +8719,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -8723,7 +8728,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -8738,7 +8743,7 @@
       "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
       "integrity": "sha1-3UIkjrlrtqUVIXJDIccv+Vg93oA=",
       "requires": {
-        "lodash": "~2.4.1"
+        "lodash": "2.4.2"
       },
       "dependencies": {
         "lodash": {
@@ -8759,11 +8764,11 @@
       "integrity": "sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==",
       "dev": true,
       "requires": {
-        "glob": "~7.0.6",
-        "make-plural": "^4.1.1",
-        "messageformat-parser": "^1.1.0",
-        "nopt": "~3.0.6",
-        "reserved-words": "^0.1.2"
+        "glob": "7.0.6",
+        "make-plural": "4.2.0",
+        "messageformat-parser": "1.1.0",
+        "nopt": "3.0.6",
+        "reserved-words": "0.1.2"
       },
       "dependencies": {
         "glob": {
@@ -8772,12 +8777,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -8809,7 +8814,7 @@
       "resolved": "https://registry.npmjs.org/micro-compress/-/micro-compress-1.0.0.tgz",
       "integrity": "sha1-U/WoC0rQMgyhZaVZtuPfFF1PcE8=",
       "requires": {
-        "compression": "^1.6.2"
+        "compression": "1.7.2"
       }
     },
     "micromatch": {
@@ -8817,19 +8822,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -8837,8 +8842,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -8856,7 +8861,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -8874,7 +8879,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "minimalistic-assert": {
@@ -8892,7 +8897,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -8905,8 +8910,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
       "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -8926,7 +8931,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "mitt": {
@@ -8939,8 +8944,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8948,7 +8953,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -8991,18 +8996,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -9060,7 +9065,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz",
       "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-emoji": {
@@ -9068,7 +9073,7 @@
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash.toarray": "4.4.0"
       }
     },
     "node-eta": {
@@ -9081,8 +9086,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-int64": {
@@ -9095,28 +9100,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.1",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -9132,8 +9137,8 @@
       "resolved": "https://registry.npmjs.org/node-rest-client/-/node-rest-client-1.8.0.tgz",
       "integrity": "sha1-jTxWa4F+JzlMtyc3g6Qcrv4+WVU=",
       "requires": {
-        "debug": "~2.2.0",
-        "xml2js": ">=0.2.4"
+        "debug": "2.2.0",
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "debug": {
@@ -9161,8 +9166,8 @@
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
+        "inherits": "2.0.3",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -9175,10 +9180,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -9199,7 +9204,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -9207,10 +9212,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -9218,7 +9223,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -9231,10 +9236,10 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
       }
     },
     "npm-run-path": {
@@ -9242,7 +9247,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -9250,9 +9255,9 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
       "integrity": "sha1-Ag+ZNR8MAuOZxnS6JW58TTs90pg=",
       "requires": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.1.4",
+        "gauge": "1.2.7"
       }
     },
     "nth-check": {
@@ -9260,7 +9265,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-loader": {
@@ -9298,9 +9303,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -9308,7 +9313,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -9328,7 +9333,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9344,10 +9349,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "optional": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -9356,7 +9361,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "optional": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -9373,8 +9378,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "optional": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -9383,7 +9388,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "optional": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -9393,8 +9398,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -9402,7 +9407,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9430,7 +9435,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onecolor": {
@@ -9443,7 +9448,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "open": {
@@ -9461,7 +9466,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -9469,8 +9474,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.2"
       }
     },
     "optionator": {
@@ -9479,12 +9484,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -9500,7 +9505,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "requires": {
-        "url-parse": "1.0.x"
+        "url-parse": "1.0.5"
       },
       "dependencies": {
         "url-parse": {
@@ -9508,8 +9513,8 @@
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "requires": {
-            "querystringify": "0.0.x",
-            "requires-port": "1.0.x"
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
           }
         }
       }
@@ -9529,9 +9534,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -9539,13 +9544,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -9560,9 +9565,9 @@
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-cancelable": {
@@ -9580,7 +9585,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -9588,7 +9593,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -9601,7 +9606,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -9614,10 +9619,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -9630,11 +9635,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-bmfont-ascii": {
@@ -9652,8 +9657,8 @@
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
       }
     },
     "parse-english": {
@@ -9661,10 +9666,10 @@
       "resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.1.tgz",
       "integrity": "sha512-g7hegR9AFIlGXl5645mG8nQeeWW7SrK7lgmgIWR0KKWvGyZO5mxa4GGoNxRLm6VW2LGpLnn6g4O9yyLJQ4IzQw==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "parse-latin": "^4.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "parse-latin": "4.1.1",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-entities": {
@@ -9672,12 +9677,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-filepath": {
@@ -9685,9 +9690,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -9695,10 +9700,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -9706,7 +9711,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "^0.3.2",
+        "for-each": "0.3.3",
         "trim": "0.0.1"
       }
     },
@@ -9715,7 +9720,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-latin": {
@@ -9723,9 +9728,9 @@
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.1.1.tgz",
       "integrity": "sha512-9fPVvDdw6G8LxL3o/PL6IzSGNGpF+3HEjCzFe0dN83sZPstftyr+McP9dNi3+EnR7ICYOHbHKCZ0l7JD90K5xQ==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-passwd": {
@@ -9738,7 +9743,7 @@
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-1.1.2.tgz",
       "integrity": "sha1-9cKtfHmTSQmGAgooTBmu5FlxH/I=",
       "requires": {
-        "pngjs": "^3.2.0"
+        "pngjs": "3.3.3"
       }
     },
     "parse5": {
@@ -9746,7 +9751,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.59"
       }
     },
     "parseqs": {
@@ -9754,7 +9759,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -9762,7 +9767,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -9815,7 +9820,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -9833,7 +9838,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -9848,11 +9853,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "pbkdf2-compat": {
@@ -9875,15 +9880,15 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.7",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.85.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -9891,9 +9896,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           }
         },
         "jsonfile": {
@@ -9901,7 +9906,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "progress": {
@@ -9926,7 +9931,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pixelmatch": {
@@ -9934,7 +9939,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "requires": {
-        "pngjs": "^3.0.0"
+        "pngjs": "3.3.3"
       }
     },
     "pixrem": {
@@ -9942,9 +9947,9 @@
       "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
       "integrity": "sha1-MNG6+0w73Ojpu0vVahOYVhkyDDQ=",
       "requires": {
-        "browserslist": "^1.0.0",
-        "postcss": "^5.0.0",
-        "reduce-css-calc": "^1.2.7"
+        "browserslist": "1.7.7",
+        "postcss": "5.2.18",
+        "reduce-css-calc": "1.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -9952,8 +9957,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000824",
+            "electron-to-chromium": "1.3.42"
           }
         }
       }
@@ -9963,10 +9968,10 @@
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
       "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
       "requires": {
-        "find-up": "^1.0.0",
-        "load-json-file": "^1.1.0",
-        "object-assign": "^4.0.1",
-        "symbol": "^0.2.1"
+        "find-up": "1.1.2",
+        "load-json-file": "1.1.0",
+        "object-assign": "4.1.1",
+        "symbol": "0.2.3"
       },
       "dependencies": {
         "load-json-file": {
@@ -9974,11 +9979,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "pify": {
@@ -9991,7 +9996,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -10001,7 +10006,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-resolve": {
@@ -10010,8 +10015,8 @@
       "integrity": "sha1-Mpsudsy7Ny4i5qOkHLMKsEV4Nro=",
       "optional": true,
       "requires": {
-        "jspm": "^0.17.0-beta.13",
-        "resolve": "^1.1.7"
+        "jspm": "0.17.0-beta.47",
+        "resolve": "1.7.0"
       }
     },
     "pkginfo": {
@@ -10024,8 +10029,8 @@
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.1.tgz",
       "integrity": "sha1-Tf4OjxBGYTUXxktyi8gGCKfr8i8=",
       "requires": {
-        "onecolor": "~2.4.0",
-        "postcss": "^5.0.4"
+        "onecolor": "2.4.2",
+        "postcss": "5.2.18"
       }
     },
     "pluralize": {
@@ -10054,10 +10059,10 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
+        "chalk": "1.1.3",
+        "js-base64": "2.4.3",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "supports-color": {
@@ -10065,7 +10070,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -10075,8 +10080,8 @@
       "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz",
       "integrity": "sha1-ovN8W9+ogeTBX08kXsDNlt0ucNU=",
       "requires": {
-        "balanced-match": "^0.4.1",
-        "postcss": "^5.0.21"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -10091,8 +10096,8 @@
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
       "integrity": "sha1-zrc3d+EGFn6yM/GTjJvZ8uaXMI0=",
       "requires": {
-        "postcss": "^5.1.1",
-        "postcss-selector-parser": "^2.2.0"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-browser-reporter": {
@@ -10100,7 +10105,7 @@
       "resolved": "https://registry.npmjs.org/postcss-browser-reporter/-/postcss-browser-reporter-0.5.0.tgz",
       "integrity": "sha1-rgad0IbVc4jRluHaw5y412Jv60g=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-calc": {
@@ -10108,9 +10113,9 @@
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
-        "postcss": "^5.0.2",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-css-calc": "^1.2.6"
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
       }
     },
     "postcss-color-function": {
@@ -10118,10 +10123,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz",
       "integrity": "sha1-mtIm9VDop8f4uKd4YFRbbdf1UkE=",
       "requires": {
-        "css-color-function": "^1.2.0",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-function": "1.3.3",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-gray": {
@@ -10129,10 +10134,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
       "integrity": "sha1-dEMu3mbdg7HRNjVlxos3bhj/Z3A=",
       "requires": {
-        "color": "^0.11.3",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-hex-alpha": {
@@ -10140,9 +10145,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
       "integrity": "sha1-RP1uyt5mAoZIyIHLZQTNy/3GzQk=",
       "requires": {
-        "color": "^0.10.1",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0"
+        "color": "0.10.1",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0"
       },
       "dependencies": {
         "color": {
@@ -10150,8 +10155,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
           "requires": {
-            "color-convert": "^0.5.3",
-            "color-string": "^0.3.0"
+            "color-convert": "0.5.3",
+            "color-string": "0.3.0"
           }
         },
         "color-convert": {
@@ -10166,9 +10171,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-1.0.5.tgz",
       "integrity": "sha1-9Tuxw0gxDOMHrYnjGBqGRzi15oc=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0",
-        "units-css": "^0.4.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "units-css": "0.4.0"
       }
     },
     "postcss-color-hwb": {
@@ -10176,10 +10181,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.1.tgz",
       "integrity": "sha1-1jr6+bcMtZX5AKKcn+V78qMvq+w=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-rebeccapurple": {
@@ -10187,8 +10192,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
       "integrity": "sha1-dMZETny7fYVhO19yht96SRYIRRw=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4"
+        "color": "0.11.4",
+        "postcss": "5.2.18"
       }
     },
     "postcss-color-rgb": {
@@ -10196,8 +10201,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-1.1.4.tgz",
       "integrity": "sha1-8pJD4i6OjBNDRHQJI3LUzmBb6Lw=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-rgba-fallback": {
@@ -10205,9 +10210,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz",
       "integrity": "sha1-bSlJG+WZCpMXPUfnx29YELCUAro=",
       "requires": {
-        "postcss": "^5.0.0",
-        "postcss-value-parser": "^3.0.2",
-        "rgb-hex": "^1.0.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "rgb-hex": "1.0.0"
       }
     },
     "postcss-colormin": {
@@ -10215,9 +10220,9 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
-        "colormin": "^1.0.5",
-        "postcss": "^5.0.13",
-        "postcss-value-parser": "^3.2.3"
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-convert-values": {
@@ -10225,8 +10230,8 @@
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
-        "postcss": "^5.0.11",
-        "postcss-value-parser": "^3.1.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-cssnext": {
@@ -10234,37 +10239,37 @@
       "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.11.0.tgz",
       "integrity": "sha1-MeaPAB5AlgTacDtm3hS4uMjJ8rE=",
       "requires": {
-        "autoprefixer": "^6.0.2",
-        "caniuse-api": "^1.5.3",
-        "chalk": "^1.1.1",
-        "pixrem": "^3.0.0",
-        "pleeease-filters": "^3.0.0",
-        "postcss": "^5.0.4",
-        "postcss-apply": "^0.3.0",
-        "postcss-attribute-case-insensitive": "^1.0.1",
-        "postcss-calc": "^5.0.0",
-        "postcss-color-function": "^2.0.0",
-        "postcss-color-gray": "^3.0.0",
-        "postcss-color-hex-alpha": "^2.0.0",
-        "postcss-color-hsl": "^1.0.5",
-        "postcss-color-hwb": "^2.0.0",
-        "postcss-color-rebeccapurple": "^2.0.0",
-        "postcss-color-rgb": "^1.1.4",
-        "postcss-color-rgba-fallback": "^2.0.0",
-        "postcss-custom-media": "^5.0.0",
-        "postcss-custom-properties": "^5.0.0",
-        "postcss-custom-selectors": "^3.0.0",
-        "postcss-font-family-system-ui": "^1.0.1",
-        "postcss-font-variant": "^2.0.0",
-        "postcss-image-set-polyfill": "^0.3.3",
-        "postcss-initial": "^1.3.1",
-        "postcss-media-minmax": "^2.1.0",
-        "postcss-nesting": "^2.0.5",
-        "postcss-pseudo-class-any-link": "^1.0.0",
-        "postcss-pseudoelements": "^3.0.0",
-        "postcss-replace-overflow-wrap": "^1.0.0",
-        "postcss-selector-matches": "^2.0.0",
-        "postcss-selector-not": "^2.0.0"
+        "autoprefixer": "6.7.7",
+        "caniuse-api": "1.6.1",
+        "chalk": "1.1.3",
+        "pixrem": "3.0.2",
+        "pleeease-filters": "3.0.1",
+        "postcss": "5.2.18",
+        "postcss-apply": "0.3.0",
+        "postcss-attribute-case-insensitive": "1.0.1",
+        "postcss-calc": "5.3.1",
+        "postcss-color-function": "2.0.1",
+        "postcss-color-gray": "3.0.1",
+        "postcss-color-hex-alpha": "2.0.0",
+        "postcss-color-hsl": "1.0.5",
+        "postcss-color-hwb": "2.0.1",
+        "postcss-color-rebeccapurple": "2.0.1",
+        "postcss-color-rgb": "1.1.4",
+        "postcss-color-rgba-fallback": "2.2.0",
+        "postcss-custom-media": "5.0.1",
+        "postcss-custom-properties": "5.0.2",
+        "postcss-custom-selectors": "3.0.0",
+        "postcss-font-family-system-ui": "1.0.2",
+        "postcss-font-variant": "2.0.1",
+        "postcss-image-set-polyfill": "0.3.5",
+        "postcss-initial": "1.5.3",
+        "postcss-media-minmax": "2.1.2",
+        "postcss-nesting": "2.3.1",
+        "postcss-pseudo-class-any-link": "1.0.0",
+        "postcss-pseudoelements": "3.0.0",
+        "postcss-replace-overflow-wrap": "1.0.0",
+        "postcss-selector-matches": "2.0.5",
+        "postcss-selector-not": "2.0.0"
       }
     },
     "postcss-custom-media": {
@@ -10272,7 +10277,7 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
       "integrity": "sha1-E40loYS/LrVN4S1VpsAcMKnYvYE=",
       "requires": {
-        "postcss": "^5.0.0"
+        "postcss": "5.2.18"
       }
     },
     "postcss-custom-properties": {
@@ -10280,8 +10285,8 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.2.tgz",
       "integrity": "sha1-lxnXjy2pz59TgQrrwj1GVhMKzrE=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -10296,9 +10301,9 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
       "integrity": "sha1-j4Ekn17Qeo0JF89qOf5bBWt/lqw=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0",
-        "postcss-selector-matches": "^2.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18",
+        "postcss-selector-matches": "2.0.5"
       },
       "dependencies": {
         "balanced-match": {
@@ -10313,7 +10318,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-duplicates": {
@@ -10321,7 +10326,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-empty": {
@@ -10329,7 +10334,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-overridden": {
@@ -10337,7 +10342,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-unused": {
@@ -10345,8 +10350,8 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-filter-plugins": {
@@ -10354,8 +10359,8 @@
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "requires": {
-        "postcss": "^5.0.4",
-        "uniqid": "^4.0.0"
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
       }
     },
     "postcss-font-family-system-ui": {
@@ -10363,9 +10368,9 @@
       "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-1.0.2.tgz",
       "integrity": "sha1-PhpeP7fjHl6ecUOcyw6AFFVpJ8c=",
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^5.2.12",
-        "postcss-value-parser": "^3.3.0"
+        "lodash": "4.17.5",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-font-variant": {
@@ -10373,7 +10378,7 @@
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
       "integrity": "sha1-fKKRA/WfoCyjrOLKIrL3VoU9Tvg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-image-set-polyfill": {
@@ -10381,8 +10386,8 @@
       "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-media-query-parser": "^0.2.3"
+        "postcss": "6.0.21",
+        "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10390,7 +10395,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10398,9 +10403,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -10413,9 +10418,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -10428,7 +10433,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10438,13 +10443,13 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-8.2.0.tgz",
       "integrity": "sha1-+S/SRU4h7077HnXADEesA/TROXw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pkg-resolve": "^0.1.7",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "promise-each": "^2.2.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
+        "object-assign": "4.1.1",
+        "pkg-resolve": "0.1.14",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "promise-each": "2.2.0",
+        "read-cache": "1.0.0",
+        "resolve": "1.7.0"
       }
     },
     "postcss-initial": {
@@ -10452,8 +10457,8 @@
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.3.tgz",
       "integrity": "sha1-IMPpHJaCLdsb7UlQjbltVrrDd9A=",
       "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^5.0.19"
+        "lodash.template": "4.4.0",
+        "postcss": "5.2.18"
       }
     },
     "postcss-loader": {
@@ -10461,8 +10466,8 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.13.0.tgz",
       "integrity": "sha1-cv2vDSlETfd9N1HOTmncQLyZ7YU=",
       "requires": {
-        "loader-utils": "^0.2.15",
-        "postcss": "^5.2.0"
+        "loader-utils": "0.2.17",
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-minmax": {
@@ -10470,7 +10475,7 @@
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
       "integrity": "sha1-RExc+JJqteT9iiUJ6Sl+dRZJzfg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-query-parser": {
@@ -10483,9 +10488,9 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-merge-longhand": {
@@ -10493,7 +10498,7 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-merge-rules": {
@@ -10501,11 +10506,11 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
-        "browserslist": "^1.5.2",
-        "caniuse-api": "^1.5.2",
-        "postcss": "^5.0.4",
-        "postcss-selector-parser": "^2.2.2",
-        "vendors": "^1.0.0"
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
       },
       "dependencies": {
         "browserslist": {
@@ -10513,8 +10518,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000824",
+            "electron-to-chromium": "1.3.42"
           }
         }
       }
@@ -10529,9 +10534,9 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-gradients": {
@@ -10539,8 +10544,8 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
-        "postcss": "^5.0.12",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-params": {
@@ -10548,10 +10553,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.2",
-        "postcss-value-parser": "^3.0.2",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -10559,10 +10564,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
-        "alphanum-sort": "^1.0.2",
-        "has": "^1.0.1",
-        "postcss": "^5.0.14",
-        "postcss-selector-parser": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-modules-extract-imports": {
@@ -10570,7 +10575,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10578,7 +10583,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10586,9 +10591,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -10601,9 +10606,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -10616,7 +10621,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10626,8 +10631,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10635,7 +10640,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10643,9 +10648,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -10658,9 +10663,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -10673,7 +10678,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10683,8 +10688,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10692,7 +10697,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10700,9 +10705,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -10715,9 +10720,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -10730,7 +10735,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10740,8 +10745,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10749,7 +10754,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10757,9 +10762,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -10772,9 +10777,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
           "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -10787,7 +10792,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10797,7 +10802,7 @@
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
       "integrity": "sha1-lKa2pO9wf77CCof+5clXdZtOAc8=",
       "requires": {
-        "postcss": "^5.0.19"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-charset": {
@@ -10805,7 +10810,7 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
-        "postcss": "^5.0.5"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-url": {
@@ -10813,10 +10818,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^1.4.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-ordered-values": {
@@ -10824,8 +10829,8 @@
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.1"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -10833,8 +10838,8 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
       "integrity": "sha1-kDI5GWQB0zX+c6x1YYb6YuaTryY=",
       "requires": {
-        "postcss": "^5.0.3",
-        "postcss-selector-parser": "^1.1.4"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "1.3.3"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -10842,9 +10847,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
           "integrity": "sha1-0u4Z33pk+O8hwacchvfUg1yIwoE=",
           "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "flatten": "1.0.2",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -10854,7 +10859,7 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz",
       "integrity": "sha1-bGghd8eQC6BTtt8X+MWQKEx7i7w=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-idents": {
@@ -10862,8 +10867,8 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-reduce-initial": {
@@ -10871,7 +10876,7 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-transforms": {
@@ -10879,9 +10884,9 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.8",
-        "postcss-value-parser": "^3.0.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -10889,7 +10894,7 @@
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz",
       "integrity": "sha1-8KA7Meq5Y2ppNr/SEOKu8bQ0pkM=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reporter": {
@@ -10897,10 +10902,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
       "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
       "requires": {
-        "chalk": "^1.0.0",
-        "lodash": "^4.1.0",
-        "log-symbols": "^1.0.2",
-        "postcss": "^5.0.0"
+        "chalk": "1.1.3",
+        "lodash": "4.17.5",
+        "log-symbols": "1.0.2",
+        "postcss": "5.2.18"
       }
     },
     "postcss-selector-matches": {
@@ -10908,8 +10913,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
       "integrity": "sha1-+g9Dvle2jneqTNEYBwI0kqExAn8=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -10924,8 +10929,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
       "integrity": "sha1-xzrSGj91I0vuf+4mnhVP1qhpeY0=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -10940,9 +10945,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-svgo": {
@@ -10950,10 +10955,10 @@
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
-        "is-svg": "^2.0.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "svgo": "^0.7.0"
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
       }
     },
     "postcss-unique-selectors": {
@@ -10961,9 +10966,9 @@
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -10976,9 +10981,9 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "prebuild-install": {
@@ -10986,21 +10991,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
       "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.1",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.6",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.0",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
       },
       "dependencies": {
         "gauge": {
@@ -11008,14 +11013,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -11023,7 +11028,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "minimist": {
@@ -11036,10 +11041,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "pump": {
@@ -11047,8 +11052,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "string-width": {
@@ -11056,9 +11061,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -11091,18 +11096,18 @@
       "integrity": "sha512-8YMkJZnA+XVfEW6fPet05jpNmSQbD+Htbh/QyOxQcVf2GIUEZsnGP7ZScaM9Mq2Ra2261eCu60E7/TRIy9coXQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "common-tags": "^1.4.0",
-        "dlv": "^1.1.0",
-        "eslint": "^4.0.0",
-        "indent-string": "^3.2.0",
-        "lodash.merge": "^4.6.0",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "prettier": "^1.7.0",
-        "pretty-format": "^22.0.3",
-        "require-relative": "^0.8.7",
-        "typescript": "^2.5.1",
-        "typescript-eslint-parser": "^11.0.0"
+        "babel-runtime": "6.26.0",
+        "common-tags": "1.7.2",
+        "dlv": "1.1.2",
+        "eslint": "4.19.1",
+        "indent-string": "3.2.0",
+        "lodash.merge": "4.6.1",
+        "loglevel-colored-level-prefix": "1.0.0",
+        "prettier": "1.12.0",
+        "pretty-format": "22.4.3",
+        "require-relative": "0.8.7",
+        "typescript": "2.9.1",
+        "typescript-eslint-parser": "11.0.0"
       },
       "dependencies": {
         "indent-string": {
@@ -11119,23 +11124,23 @@
       "integrity": "sha512-hQbsGaEVz97oBBcKdsJ46khv0kOGkMyWrXzcFOXW6X8UuetZ/j0yDJkNJgUTVc6PVFbbzBXk+qgd5vos9qzXPQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "babel-runtime": "^6.23.0",
-        "boolify": "^1.0.0",
-        "camelcase-keys": "^4.1.0",
+        "arrify": "1.0.1",
+        "babel-runtime": "6.26.0",
+        "boolify": "1.0.1",
+        "camelcase-keys": "4.2.0",
         "chalk": "2.3.0",
-        "common-tags": "^1.4.0",
-        "eslint": "^4.5.0",
-        "find-up": "^2.1.0",
-        "get-stdin": "^5.0.1",
-        "glob": "^7.1.1",
-        "ignore": "^3.2.7",
-        "indent-string": "^3.1.0",
-        "lodash.memoize": "^4.1.2",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "messageformat": "^1.0.2",
-        "prettier-eslint": "^8.5.0",
-        "rxjs": "^5.3.0",
+        "common-tags": "1.7.2",
+        "eslint": "4.19.1",
+        "find-up": "2.1.0",
+        "get-stdin": "5.0.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.8",
+        "indent-string": "3.2.0",
+        "lodash.memoize": "4.1.2",
+        "loglevel-colored-level-prefix": "1.0.0",
+        "messageformat": "1.1.1",
+        "prettier-eslint": "8.8.1",
+        "rxjs": "5.5.11",
         "yargs": "10.0.3"
       },
       "dependencies": {
@@ -11145,7 +11150,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase-keys": {
@@ -11154,9 +11159,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "chalk": {
@@ -11165,9 +11170,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "find-up": {
@@ -11176,7 +11181,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "get-stdin": {
@@ -11209,7 +11214,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         },
         "yargs": {
@@ -11218,18 +11223,18 @@
           "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.0.0"
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
           }
         },
         "yargs-parser": {
@@ -11238,7 +11243,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -11253,8 +11258,8 @@
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
       }
     },
     "pretty-format": {
@@ -11263,8 +11268,8 @@
       "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11279,7 +11284,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -11310,7 +11315,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-each": {
@@ -11318,7 +11323,7 @@
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
       "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
       "requires": {
-        "any-promise": "^0.1.0"
+        "any-promise": "0.1.0"
       }
     },
     "prop-types": {
@@ -11326,9 +11331,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "proper-lockfile": {
@@ -11337,10 +11342,10 @@
       "integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
       "optional": true,
       "requires": {
-        "err-code": "^1.0.0",
-        "extend": "^3.0.0",
-        "graceful-fs": "^4.1.2",
-        "retry": "^0.10.0"
+        "err-code": "1.1.2",
+        "extend": "3.0.1",
+        "graceful-fs": "4.1.11",
+        "retry": "0.10.1"
       }
     },
     "property-information": {
@@ -11353,7 +11358,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -11372,11 +11377,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
@@ -11384,8 +11389,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -11408,8 +11413,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -11438,8 +11443,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -11447,7 +11452,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11455,7 +11460,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11465,7 +11470,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -11475,7 +11480,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "randomfill": {
@@ -11483,8 +11488,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "range-parser": {
@@ -11516,7 +11521,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "setprototypeof": {
@@ -11536,10 +11541,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -11554,11 +11559,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "create-react-class": "15.6.3",
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "react-deep-force-update": {
@@ -11583,7 +11588,7 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.1.0",
-        "react-error-overlay": "^3.0.0",
+        "react-error-overlay": "3.0.0",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.4",
@@ -11596,8 +11601,8 @@
           "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
           "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
           "requires": {
-            "address": "^1.0.1",
-            "debug": "^2.6.0"
+            "address": "1.0.3",
+            "debug": "2.6.9"
           }
         },
         "opn": {
@@ -11605,7 +11610,7 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
           "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
           "requires": {
-            "is-wsl": "^1.1.0"
+            "is-wsl": "1.1.0"
           }
         }
       }
@@ -11615,10 +11620,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "react-error-overlay": {
@@ -11631,10 +11636,10 @@
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
       "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
       "requires": {
-        "deep-equal": "^1.0.1",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-side-effect": "^1.1.0"
+        "deep-equal": "1.0.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "react-side-effect": "1.1.3"
       }
     },
     "react-hot-loader": {
@@ -11642,11 +11647,11 @@
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.3.tgz",
       "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
       "requires": {
-        "global": "^4.3.0",
-        "react-deep-force-update": "^2.1.1",
-        "react-proxy": "^3.0.0-alpha.0",
-        "redbox-react": "^1.3.6",
-        "source-map": "^0.6.1"
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -11661,7 +11666,7 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.5"
       }
     },
     "react-router": {
@@ -11669,13 +11674,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
       "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.3.0",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.5.4",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -11698,12 +11703,12 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
       "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.4",
-        "react-router": "^4.2.0",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "react-router": "4.2.0",
+        "warning": "3.0.0"
       }
     },
     "react-side-effect": {
@@ -11711,8 +11716,8 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.3.tgz",
       "integrity": "sha1-USwlq+DewXKDTEAB7FxR4E1BvFw=",
       "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
       }
     },
     "read": {
@@ -11720,7 +11725,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-cache": {
@@ -11728,7 +11733,7 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "requires": {
-        "pify": "^2.3.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -11748,9 +11753,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -11758,8 +11763,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -11767,7 +11772,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -11777,13 +11782,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdir-enhanced": {
@@ -11791,9 +11796,9 @@
       "resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
       "integrity": "sha1-YUYwSGkKxqRVt1ti+nioj43IXlM=",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "es6-promise": "^4.1.0",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "es6-promise": "4.2.4",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "readdirp": {
@@ -11801,10 +11806,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "rechoir": {
@@ -11812,7 +11817,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.7.0"
       }
     },
     "recursive-readdir": {
@@ -11828,7 +11833,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -11838,10 +11843,10 @@
       "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
       "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
       "requires": {
-        "error-stack-parser": "^1.3.6",
-        "object-assign": "^4.0.1",
-        "prop-types": "^15.5.4",
-        "sourcemapped-stacktrace": "^1.1.6"
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "sourcemapped-stacktrace": "1.1.8"
       },
       "dependencies": {
         "error-stack-parser": {
@@ -11849,7 +11854,7 @@
           "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
           "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
           "requires": {
-            "stackframe": "^0.3.1"
+            "stackframe": "0.3.1"
           }
         },
         "stackframe": {
@@ -11864,8 +11869,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -11873,9 +11878,9 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -11890,7 +11895,7 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -11905,10 +11910,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.8",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-devtools-instrument": {
@@ -11916,8 +11921,8 @@
       "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz",
       "integrity": "sha1-xRDWerTl5FJazW5BDCWrRrhaynw=",
       "requires": {
-        "lodash": "^4.2.0",
-        "symbol-observable": "^1.0.2"
+        "lodash": "4.17.5",
+        "symbol-observable": "1.2.0"
       }
     },
     "regenerate": {
@@ -11935,9 +11940,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -11945,7 +11950,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -11953,8 +11958,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpp": {
@@ -11968,9 +11973,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -11978,8 +11983,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
@@ -11987,7 +11992,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.6"
       }
     },
     "regjsgen": {
@@ -12000,7 +12005,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12015,22 +12020,22 @@
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.4.1.tgz",
       "integrity": "sha512-8O9dVIOOTp1TlbQhdNp2EBO/WUaSEPaYhQ8HFgMVjpvLTCaCfHEpptNQPJf5uDG/AH1p2qhPtLaCyQ2pBYh7Cw==",
       "requires": {
-        "babel-generator": "^6.24.1",
-        "babel-polyfill": "^6.20.0",
-        "babel-preset-fbjs": "^2.1.4",
-        "babel-runtime": "^6.23.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.24.1",
-        "babylon": "^6.18.0",
-        "chalk": "^1.1.1",
-        "fast-glob": "^1.0.1",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^0.8.14",
-        "graphql": "^0.11.3",
-        "immutable": "~3.7.6",
+        "babel-generator": "6.26.1",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-fbjs": "2.1.4",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "chalk": "1.1.3",
+        "fast-glob": "1.0.1",
+        "fb-watchman": "2.0.0",
+        "fbjs": "0.8.16",
+        "graphql": "0.11.7",
+        "immutable": "3.7.6",
         "relay-runtime": "1.4.1",
-        "signedsource": "^1.0.0",
-        "yargs": "^9.0.0"
+        "signedsource": "1.0.0",
+        "yargs": "9.0.1"
       },
       "dependencies": {
         "yargs": {
@@ -12038,19 +12043,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         }
       }
@@ -12065,8 +12070,8 @@
       "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.4.1.tgz",
       "integrity": "sha512-hsEVCPik0Wo+8xvVqaMK96d45fqYAcHz/UCAw2qy1dxY+2kHUhnDUh6CGilFKB1H3f+DLzvqIHUyNYKWS/jZ/g==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "fbjs": "^0.8.14",
+        "babel-runtime": "6.26.0",
+        "fbjs": "0.8.16",
         "relay-debugger-react-native-runtime": "0.0.10"
       }
     },
@@ -12075,9 +12080,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-7.0.1.tgz",
       "integrity": "sha1-pd5NrPq/D2CkmCbvJMR5gH+QS/s=",
       "requires": {
-        "remark-parse": "^3.0.0",
-        "remark-stringify": "^3.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "3.0.1",
+        "remark-stringify": "3.0.1",
+        "unified": "6.2.0"
       },
       "dependencies": {
         "remark-parse": {
@@ -12085,22 +12090,22 @@
           "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
           "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
           "requires": {
-            "collapse-white-space": "^1.0.2",
-            "has": "^1.0.1",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
+            "collapse-white-space": "1.0.4",
+            "has": "1.0.1",
+            "is-alphabetical": "1.0.2",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "is-word-character": "1.0.2",
+            "markdown-escapes": "1.0.2",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
             "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
+            "trim-trailing-lines": "1.1.1",
+            "unherit": "1.1.1",
+            "unist-util-remove-position": "1.1.2",
+            "vfile-location": "2.0.3",
+            "xtend": "4.0.1"
           }
         },
         "remark-stringify": {
@@ -12108,20 +12113,20 @@
           "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
           "integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
           "requires": {
-            "ccount": "^1.0.0",
-            "is-alphanumeric": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "longest-streak": "^2.0.1",
-            "markdown-escapes": "^1.0.0",
-            "markdown-table": "^1.1.0",
-            "mdast-util-compact": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "stringify-entities": "^1.0.1",
-            "unherit": "^1.0.4",
-            "xtend": "^4.0.1"
+            "ccount": "1.0.3",
+            "is-alphanumeric": "1.0.0",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "longest-streak": "2.0.2",
+            "markdown-escapes": "1.0.2",
+            "markdown-table": "1.1.2",
+            "mdast-util-compact": "1.0.1",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
+            "stringify-entities": "1.3.2",
+            "unherit": "1.1.1",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -12131,21 +12136,21 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
       "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.4",
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "is-word-character": "1.0.2",
+        "markdown-escapes": "1.0.2",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.1",
+        "unherit": "1.1.1",
+        "unist-util-remove-position": "1.1.2",
+        "vfile-location": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "remark-retext": {
@@ -12153,7 +12158,7 @@
       "resolved": "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.0.tgz",
       "integrity": "sha1-Gz3y1JRpwNNZbK2G6RUDqLYA/cw=",
       "requires": {
-        "mdast-util-to-nlcst": "^3.2.0"
+        "mdast-util-to-nlcst": "3.2.0"
       }
     },
     "remark-stringify": {
@@ -12161,20 +12166,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
       "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.2",
+        "markdown-table": "1.1.2",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
+        "stringify-entities": "1.3.2",
+        "unherit": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "remote-redux-devtools": {
@@ -12182,12 +12187,12 @@
       "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz",
       "integrity": "sha1-QsuV36nlTB2WcTF8Xnu6QeaMrsI=",
       "requires": {
-        "jsan": "^3.1.5",
-        "querystring": "^0.2.0",
-        "redux-devtools-instrument": "^1.3.3",
-        "remotedev-utils": "^0.1.1",
-        "rn-host-detect": "^1.0.1",
-        "socketcluster-client": "^5.3.1"
+        "jsan": "3.1.9",
+        "querystring": "0.2.0",
+        "redux-devtools-instrument": "1.8.3",
+        "remotedev-utils": "0.1.4",
+        "rn-host-detect": "1.1.3",
+        "socketcluster-client": "5.5.2"
       }
     },
     "remotedev-serialize": {
@@ -12195,7 +12200,7 @@
       "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz",
       "integrity": "sha1-D1mAALfddRXWf5tRph0hHhjOlVQ=",
       "requires": {
-        "jsan": "^3.1.9"
+        "jsan": "3.1.9"
       }
     },
     "remotedev-utils": {
@@ -12203,11 +12208,11 @@
       "resolved": "https://registry.npmjs.org/remotedev-utils/-/remotedev-utils-0.1.4.tgz",
       "integrity": "sha1-ZDcAgZqUNngHPHXrGF6B2WYgs0g=",
       "requires": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.5",
-        "lodash": "^4.0.0",
-        "remotedev-serialize": "^0.1.0",
-        "shortid": "^2.2.6"
+        "get-params": "0.1.2",
+        "jsan": "3.1.9",
+        "lodash": "4.17.5",
+        "remotedev-serialize": "0.1.1",
+        "shortid": "2.2.8"
       }
     },
     "remove-trailing-separator": {
@@ -12220,11 +12225,11 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.1",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "~0.3"
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -12249,7 +12254,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -12262,28 +12267,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "request-progress": {
@@ -12291,7 +12296,7 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "require-directory": {
@@ -12321,8 +12326,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       },
       "dependencies": {
         "resolve-from": {
@@ -12350,11 +12355,11 @@
       "integrity": "sha1-+tZQ+vPvLFPqYxErwnLZXp2SVQ4=",
       "requires": {
         "bmp-js": "0.0.1",
-        "file-type": "^3.8.0",
-        "get-stream": "^2.0.0",
-        "jimp": "^0.2.21",
-        "jpeg-js": "^0.1.1",
-        "parse-png": "^1.1.1"
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
+        "jimp": "0.2.28",
+        "jpeg-js": "0.1.2",
+        "parse-png": "1.1.2"
       },
       "dependencies": {
         "bmp-js": {
@@ -12367,8 +12372,8 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "jpeg-js": {
@@ -12383,7 +12388,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
       "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -12391,7 +12396,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -12399,8 +12404,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -12408,7 +12413,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -12433,8 +12438,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -12447,8 +12452,8 @@
       "resolved": "https://registry.npmjs.org/retext-english/-/retext-english-3.0.0.tgz",
       "integrity": "sha1-wXy1a9Xxuj3uM1XdurefHEiUqAk=",
       "requires": {
-        "parse-english": "^4.0.0",
-        "unherit": "^1.0.4"
+        "parse-english": "4.1.1",
+        "unherit": "1.1.1"
       }
     },
     "retry": {
@@ -12477,7 +12482,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -12485,7 +12490,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -12493,8 +12498,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
       }
     },
     "rn-host-detect": {
@@ -12508,7 +12513,7 @@
       "integrity": "sha1-oiRJTFOGwdc9OPe7hvafXrARo9I=",
       "optional": true,
       "requires": {
-        "source-map-support": "^0.4.0"
+        "source-map-support": "0.4.18"
       }
     },
     "rsvp": {
@@ -12521,7 +12526,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -12534,7 +12539,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "rxjs": {
@@ -12564,7 +12569,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "sane": {
@@ -12573,13 +12578,13 @@
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
       "optional": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "minimatch": "^3.0.2",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.10.0"
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
       },
       "dependencies": {
         "minimist": {
@@ -12595,16 +12600,16 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.2.tgz",
       "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
       "requires": {
-        "chalk": "^2.3.0",
-        "htmlparser2": "^3.9.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.0",
-        "postcss": "^6.0.14",
-        "srcset": "^1.0.0",
-        "xtend": "^4.0.0"
+        "chalk": "2.4.1",
+        "htmlparser2": "3.9.2",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.escaperegexp": "4.1.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.mergewith": "4.6.1",
+        "postcss": "6.0.22",
+        "srcset": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12612,7 +12617,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -12620,9 +12625,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "domhandler": {
@@ -12630,7 +12635,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "has-flag": {
@@ -12643,12 +12648,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "postcss": {
@@ -12656,9 +12661,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -12671,7 +12676,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12686,7 +12691,7 @@
       "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.0.6.tgz",
       "integrity": "sha1-s4vUepk+eCkPvFNGeGf2sqCghjk=",
       "requires": {
-        "sc-emitter": "1.x.x"
+        "sc-emitter": "1.1.0"
       }
     },
     "sc-emitter": {
@@ -12719,8 +12724,8 @@
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.9.tgz",
       "integrity": "sha1-6/4GWEVbgq2IW2YZUhVBZnTazOI=",
       "requires": {
-        "dom-helpers": "^3.2.1",
-        "invariant": "^2.2.2"
+        "dom-helpers": "3.3.1",
+        "invariant": "2.2.4"
       }
     },
     "semver": {
@@ -12733,7 +12738,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -12742,18 +12747,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -12797,7 +12802,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -12805,9 +12810,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "filesize": {
@@ -12820,9 +12825,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "has-flag": {
@@ -12835,7 +12840,7 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
           "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
           "requires": {
-            "is-wsl": "^1.1.0"
+            "is-wsl": "1.1.0"
           }
         },
         "path-type": {
@@ -12843,7 +12848,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "supports-color": {
@@ -12851,7 +12856,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12861,13 +12866,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -12875,9 +12880,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -12901,10 +12906,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12912,7 +12917,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -12932,8 +12937,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shallow-compare": {
@@ -12951,16 +12956,16 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.3.tgz",
       "integrity": "sha512-9P6WclSW4GZg3I2ej3p/Xphsa2kl4b5pZaKMZXaFA5CRN91zzeJoZxLmXFUsjOY7ppIaMLXDOMs0zR2LYzjE/w==",
       "requires": {
-        "color": "^3.0.0",
-        "detect-libc": "^1.0.3",
-        "fs-copy-file-sync": "^1.1.1",
-        "nan": "^2.10.0",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^4.0.0",
-        "semver": "^5.5.0",
-        "simple-get": "^2.8.1",
-        "tar": "^4.4.4",
-        "tunnel-agent": "^0.6.0"
+        "color": "3.0.0",
+        "detect-libc": "1.0.3",
+        "fs-copy-file-sync": "1.1.1",
+        "nan": "2.10.0",
+        "npmlog": "4.1.2",
+        "prebuild-install": "4.0.0",
+        "semver": "5.5.0",
+        "simple-get": "2.8.1",
+        "tar": "4.4.4",
+        "tunnel-agent": "0.6.0"
       },
       "dependencies": {
         "color": {
@@ -12968,8 +12973,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
           "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
+            "color-convert": "1.9.1",
+            "color-string": "1.5.2"
           }
         },
         "color-string": {
@@ -12977,8 +12982,8 @@
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
           "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         },
         "gauge": {
@@ -12986,14 +12991,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -13001,7 +13006,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "npmlog": {
@@ -13009,10 +13014,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "string-width": {
@@ -13020,9 +13025,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -13032,7 +13037,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -13045,10 +13050,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "shelljs": {
@@ -13056,9 +13061,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.0.tgz",
       "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=",
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       },
       "dependencies": {
         "interpret": {
@@ -13098,9 +13103,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "simple-swizzle": {
@@ -13108,7 +13113,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -13129,7 +13134,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snapdragon": {
@@ -13137,14 +13142,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13152,7 +13157,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -13160,7 +13165,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -13170,9 +13175,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -13180,7 +13185,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -13188,7 +13193,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -13196,7 +13201,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -13204,9 +13209,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -13226,7 +13231,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -13234,7 +13239,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "socket.io": {
@@ -13242,12 +13247,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.0.tgz",
       "integrity": "sha512-KS+3CNWWNtLbVN5j0/B+1hjxRzey+oTK6ejpAOoxMZis6aXeB8cUtfuvjHl97tuZx+t/qD/VyqFMjuzu2Js6uQ==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.2",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.0",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -13274,15 +13279,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -13302,7 +13307,7 @@
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -13330,10 +13335,10 @@
         "clone": "2.1.1",
         "linked-list": "0.1.0",
         "querystring": "0.2.0",
-        "sc-channel": "~1.0.6",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "sc-formatter": "~3.0.0",
+        "sc-channel": "1.0.6",
+        "sc-emitter": "1.1.0",
+        "sc-errors": "1.3.3",
+        "sc-formatter": "3.0.2",
         "ws": "3.0.0"
       },
       "dependencies": {
@@ -13349,8 +13354,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "faye-websocket": {
@@ -13358,7 +13363,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -13368,12 +13373,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.3.0"
       }
     },
     "sort-keys": {
@@ -13381,7 +13386,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-list-map": {
@@ -13399,11 +13404,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -13411,7 +13416,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -13447,8 +13452,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -13461,8 +13466,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -13475,7 +13480,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -13488,8 +13493,8 @@
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
-        "array-uniq": "^1.0.2",
-        "number-is-nan": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "number-is-nan": "1.0.1"
       }
     },
     "sshpk": {
@@ -13497,14 +13502,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -13527,8 +13532,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13536,7 +13541,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -13546,11 +13551,11 @@
       "resolved": "https://registry.npmjs.org/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-3.4.1.tgz",
       "integrity": "sha1-buIkaIMLxUZ5ijfg/Kb9aZzJO4E=",
       "requires": {
-        "bluebird": "^3.0.5",
-        "cheerio": "^0.22.0",
-        "eval": "^0.1.0",
-        "url": "^0.11.0",
-        "webpack-sources": "^0.2.0"
+        "bluebird": "3.5.1",
+        "cheerio": "0.22.0",
+        "eval": "0.1.2",
+        "url": "0.11.0",
+        "webpack-sources": "0.2.3"
       },
       "dependencies": {
         "source-list-map": {
@@ -13563,8 +13568,8 @@
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
           "requires": {
-            "source-list-map": "^1.1.1",
-            "source-map": "~0.5.3"
+            "source-list-map": "1.1.2",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -13579,7 +13584,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
       "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "graceful-fs": "^4.1.3"
+        "graceful-fs": "4.1.11"
       }
     },
     "stream-browserify": {
@@ -13587,8 +13592,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-cache": {
@@ -13601,11 +13606,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
       "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-to": {
@@ -13618,7 +13623,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "requires": {
-        "stream-to": "~0.2.0"
+        "stream-to": "0.2.2"
       }
     },
     "strict-uri-encode": {
@@ -13631,7 +13636,7 @@
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-1.2.0.tgz",
       "integrity": "sha1-11FTyzg4RjGLejmo2SkrtNtOnDA=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.5"
       }
     },
     "string-width": {
@@ -13639,8 +13644,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13653,7 +13658,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -13663,7 +13668,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {
@@ -13671,10 +13676,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "stringstream": {
@@ -13687,7 +13692,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -13710,7 +13715,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -13723,7 +13728,7 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
       "requires": {
-        "loader-utils": "^1.0.2"
+        "loader-utils": "1.1.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -13731,9 +13736,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -13748,9 +13753,9 @@
       "resolved": "https://registry.npmjs.org/svg2png/-/svg2png-3.0.1.tgz",
       "integrity": "sha1-omRNaLAjGsAK9DGqFjcU/xcQZEc=",
       "requires": {
-        "phantomjs-prebuilt": "^2.1.10",
-        "pn": "^1.0.0",
-        "yargs": "^3.31.0"
+        "phantomjs-prebuilt": "2.1.16",
+        "pn": "1.1.0",
+        "yargs": "3.32.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13763,7 +13768,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "os-locale": {
@@ -13771,7 +13776,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "string-width": {
@@ -13779,9 +13784,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "window-size": {
@@ -13794,13 +13799,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -13810,13 +13815,13 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
       }
     },
     "sw-precache": {
@@ -13824,16 +13829,16 @@
       "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
       "requires": {
-        "dom-urls": "^1.1.0",
-        "es6-promise": "^4.0.5",
-        "glob": "^7.1.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.template": "^4.4.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "pretty-bytes": "^4.0.2",
-        "sw-toolbox": "^3.4.0",
-        "update-notifier": "^2.3.0"
+        "dom-urls": "1.1.0",
+        "es6-promise": "4.2.4",
+        "glob": "7.1.2",
+        "lodash.defaults": "4.2.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "pretty-bytes": "4.0.2",
+        "sw-toolbox": "3.6.0",
+        "update-notifier": "2.4.0"
       }
     },
     "sw-toolbox": {
@@ -13841,8 +13846,8 @@
       "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
-        "path-to-regexp": "^1.0.1",
-        "serviceworker-cache-polyfill": "^4.0.0"
+        "path-to-regexp": "1.7.0",
+        "serviceworker-cache-polyfill": "4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -13882,23 +13887,23 @@
       "integrity": "sha512-E+INOPzUsi1VpXat3GYDKl1Xap3Acv3Bw6KmRC9TdpfdJnTk6Jh5K07DdM8P+LEPXZaLZvTaaN/5q2i+1FD1vA==",
       "optional": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-amd-system-wrapper": "^0.3.7",
-        "babel-plugin-transform-cjs-system-wrapper": "^0.6.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.6.5",
-        "babel-plugin-transform-global-system-wrapper": "^0.3.4",
-        "babel-plugin-transform-system-register": "^0.0.1",
-        "bluebird": "^3.3.4",
+        "babel-core": "6.26.0",
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-amd-system-wrapper": "0.3.7",
+        "babel-plugin-transform-cjs-system-wrapper": "0.6.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-global-system-wrapper": "0.3.4",
+        "babel-plugin-transform-system-register": "0.0.1",
+        "bluebird": "3.5.1",
         "data-uri-to-buffer": "0.0.4",
-        "es6-template-strings": "^2.0.0",
-        "glob": "^7.0.3",
-        "mkdirp": "^0.5.1",
-        "rollup": "^0.36.3",
-        "source-map": "^0.5.3",
-        "systemjs": "^0.19.46",
+        "es6-template-strings": "2.0.1",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "rollup": "0.36.4",
+        "source-map": "0.5.7",
+        "systemjs": "0.19.47",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "systemjs": {
@@ -13907,7 +13912,7 @@
           "integrity": "sha1-yMk5NxgPP1SBx2nNJyB2P7SjHG8=",
           "optional": true,
           "requires": {
-            "when": "^3.7.5"
+            "when": "3.7.8"
           }
         }
       }
@@ -13918,12 +13923,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.1",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13932,7 +13937,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -13941,9 +13946,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -13958,7 +13963,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13973,13 +13978,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
       "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.3",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -13999,10 +14004,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
       }
     },
     "tar-stream": {
@@ -14010,10 +14015,10 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "term-size": {
@@ -14021,7 +14026,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       },
       "dependencies": {
         "execa": {
@@ -14029,13 +14034,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -14060,8 +14065,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -14079,7 +14084,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
       "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tinycolor2": {
@@ -14092,7 +14097,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -14121,11 +14126,11 @@
       "resolved": "https://registry.npmjs.org/to-ico/-/to-ico-1.1.5.tgz",
       "integrity": "sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==",
       "requires": {
-        "arrify": "^1.0.1",
-        "buffer-alloc": "^1.1.0",
-        "image-size": "^0.5.0",
-        "parse-png": "^1.0.0",
-        "resize-img": "^1.1.0"
+        "arrify": "1.0.1",
+        "buffer-alloc": "1.1.0",
+        "image-size": "0.5.5",
+        "parse-png": "1.1.2",
+        "resize-img": "1.1.2"
       },
       "dependencies": {
         "image-size": {
@@ -14140,7 +14145,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -14148,10 +14153,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -14159,8 +14164,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -14168,7 +14173,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -14178,7 +14183,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "tough-cookie": {
@@ -14186,7 +14191,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -14201,11 +14206,11 @@
       "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.105.tgz",
       "integrity": "sha1-XPne6D1rd4YcPWxE1ThZrterBHk=",
       "requires": {
-        "commander": "2.9.x",
-        "glob": "5.0.x",
-        "rsvp": "^3.0.13",
-        "semver": "^4.3.3",
-        "source-map-support": "~0.2.8"
+        "commander": "2.9.0",
+        "glob": "5.0.15",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6",
+        "source-map-support": "0.2.10"
       },
       "dependencies": {
         "glob": {
@@ -14213,11 +14218,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "semver": {
@@ -14230,7 +14235,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "source-map-support": {
@@ -14288,7 +14293,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -14303,7 +14308,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -14312,7 +14317,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "type-of": {
@@ -14359,9 +14364,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -14374,8 +14379,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -14384,9 +14389,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -14417,8 +14422,8 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "unherit": {
@@ -14426,8 +14431,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -14435,12 +14440,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-string": "^0.1.0"
+        "bail": "1.0.3",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.2",
+        "vfile": "2.3.0",
+        "x-is-string": "0.1.0"
       }
     },
     "union-value": {
@@ -14448,10 +14453,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -14459,7 +14464,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -14467,10 +14472,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -14485,7 +14490,7 @@
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "requires": {
-        "macaddress": "^0.2.8"
+        "macaddress": "0.2.8"
       }
     },
     "uniqs": {
@@ -14498,7 +14503,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-builder": {
@@ -14506,7 +14511,7 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
       "integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
       "requires": {
-        "object-assign": "^4.1.0"
+        "object-assign": "4.1.1"
       }
     },
     "unist-util-generated": {
@@ -14524,7 +14529,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "^1.0.0"
+        "array-iterate": "1.1.2"
       }
     },
     "unist-util-position": {
@@ -14537,7 +14542,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.3.1"
       }
     },
     "unist-util-select": {
@@ -14545,9 +14550,9 @@
       "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
       "integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
       "requires": {
-        "css-selector-parser": "^1.1.0",
-        "debug": "^2.2.0",
-        "nth-check": "^1.0.1"
+        "css-selector-parser": "1.3.0",
+        "debug": "2.6.9",
+        "nth-check": "1.0.1"
       }
     },
     "unist-util-stringify-position": {
@@ -14560,7 +14565,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
       "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-is": "2.1.2"
       }
     },
     "unist-util-visit-children": {
@@ -14573,8 +14578,8 @@
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
       "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
       "requires": {
-        "isnumeric": "^0.2.0",
-        "viewport-dimensions": "^0.2.0"
+        "isnumeric": "0.2.0",
+        "viewport-dimensions": "0.2.0"
       }
     },
     "universalify": {
@@ -14592,8 +14597,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -14601,9 +14606,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -14647,16 +14652,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
       "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.3.2",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14664,7 +14669,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14672,9 +14677,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14687,7 +14692,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14723,8 +14728,8 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
       "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "requires": {
-        "loader-utils": "^1.0.2",
-        "mime": "1.3.x"
+        "loader-utils": "1.1.0",
+        "mime": "1.3.6"
       },
       "dependencies": {
         "loader-utils": {
@@ -14732,9 +14737,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "mime": {
@@ -14749,8 +14754,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
       "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
       "requires": {
-        "querystringify": "~1.0.0",
-        "requires-port": "~1.0.0"
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -14765,7 +14770,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -14773,7 +14778,7 @@
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "url-to-options": {
@@ -14786,7 +14791,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -14846,7 +14851,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "valid-url": {
@@ -14859,8 +14864,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-equal": {
@@ -14883,9 +14888,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -14893,10 +14898,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "1.1.6",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-message": "1.0.1"
       }
     },
     "vfile-location": {
@@ -14909,7 +14914,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.2"
       }
     },
     "viewport-dimensions": {
@@ -14922,8 +14927,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -14948,7 +14953,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "optional": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "warning": {
@@ -14956,7 +14961,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "watch": {
@@ -14970,9 +14975,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "requires": {
-        "async": "^0.9.0",
-        "chokidar": "^1.0.0",
-        "graceful-fs": "^4.1.2"
+        "async": "0.9.2",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "async": {
@@ -14992,21 +14997,21 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "requires": {
-        "acorn": "^3.0.0",
-        "async": "^1.3.0",
-        "clone": "^1.0.2",
-        "enhanced-resolve": "~0.9.0",
-        "interpret": "^0.6.4",
-        "loader-utils": "^0.2.11",
-        "memory-fs": "~0.3.0",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^0.7.0",
-        "optimist": "~0.6.0",
-        "supports-color": "^3.1.0",
-        "tapable": "~0.1.8",
-        "uglify-js": "~2.7.3",
-        "watchpack": "^0.2.1",
-        "webpack-core": "~0.6.9"
+        "acorn": "3.3.0",
+        "async": "1.5.2",
+        "clone": "1.0.4",
+        "enhanced-resolve": "0.9.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.7.0",
+        "optimist": "0.6.1",
+        "supports-color": "3.2.3",
+        "tapable": "0.1.10",
+        "uglify-js": "2.7.5",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.9"
       },
       "dependencies": {
         "async": {
@@ -15019,7 +15024,7 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
           "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
           "requires": {
-            "inherits": "^2.0.1"
+            "inherits": "2.0.3"
           }
         },
         "browserify-zlib": {
@@ -15027,7 +15032,7 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "~0.2.0"
+            "pako": "0.2.9"
           }
         },
         "camelcase": {
@@ -15040,8 +15045,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -15066,28 +15071,28 @@
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
           "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
           "requires": {
-            "assert": "^1.1.1",
-            "browserify-zlib": "^0.1.4",
-            "buffer": "^4.9.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "^1.0.0",
+            "assert": "1.4.1",
+            "browserify-zlib": "0.1.4",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
             "crypto-browserify": "3.3.0",
-            "domain-browser": "^1.1.1",
-            "events": "^1.0.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
             "https-browserify": "0.0.1",
-            "os-browserify": "^0.2.0",
+            "os-browserify": "0.2.1",
             "path-browserify": "0.0.0",
-            "process": "^0.11.0",
-            "punycode": "^1.2.4",
-            "querystring-es3": "^0.2.0",
-            "readable-stream": "^2.0.5",
-            "stream-browserify": "^2.0.1",
-            "stream-http": "^2.3.1",
-            "string_decoder": "^0.10.25",
-            "timers-browserify": "^2.0.2",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.6",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.1",
+            "string_decoder": "0.10.31",
+            "timers-browserify": "2.0.6",
             "tty-browserify": "0.0.0",
-            "url": "^0.11.0",
-            "util": "^0.10.3",
+            "url": "0.11.0",
+            "util": "0.10.3",
             "vm-browserify": "0.0.4"
           }
         },
@@ -15126,7 +15131,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "uglify-js": {
@@ -15134,10 +15139,10 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "async": {
@@ -15152,8 +15157,8 @@
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
           "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
           "requires": {
-            "source-list-map": "~0.1.7",
-            "source-map": "~0.4.1"
+            "source-list-map": "0.1.8",
+            "source-map": "0.4.4"
           },
           "dependencies": {
             "source-map": {
@@ -15161,7 +15166,7 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -15171,9 +15176,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -15199,7 +15204,7 @@
       "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
       "integrity": "sha1-B/xVq6gdF9uoyuWkPWvWkjb4tfg=",
       "requires": {
-        "source-map": "~0.1.38"
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "source-map": {
@@ -15207,7 +15212,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -15217,11 +15222,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.0"
       },
       "dependencies": {
         "memory-fs": {
@@ -15229,8 +15234,8 @@
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -15240,19 +15245,19 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
       "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
       "requires": {
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "express": "^4.13.3",
-        "http-proxy-middleware": "~0.17.1",
+        "compression": "1.7.2",
+        "connect-history-api-fallback": "1.5.0",
+        "express": "4.16.3",
+        "http-proxy-middleware": "0.17.4",
         "open": "0.0.5",
-        "optimist": "~0.6.1",
-        "serve-index": "^1.7.2",
-        "sockjs": "^0.3.15",
-        "sockjs-client": "^1.0.3",
-        "stream-cache": "~0.0.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^3.1.1",
-        "webpack-dev-middleware": "^1.10.2"
+        "optimist": "0.6.1",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "stream-cache": "0.0.2",
+        "strip-ansi": "3.0.1",
+        "supports-color": "3.2.3",
+        "webpack-dev-middleware": "1.12.2"
       },
       "dependencies": {
         "supports-color": {
@@ -15260,7 +15265,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -15271,9 +15276,9 @@
       "integrity": "sha512-kmjTZ6WXZowuBfTk1/H/scmyp09eHwPpqF2mHRZ9WMCBlQ61NSkqZ25azPlPOeCIhva57PGrUyeTIW5X8Q7HEw==",
       "requires": {
         "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
-        "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "webpack-md5-hash": {
@@ -15281,7 +15286,7 @@
       "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz",
       "integrity": "sha1-2fGJnq1mRFndi2sMkmrHHPvXvHo=",
       "requires": {
-        "md5": "^2.0.0"
+        "md5": "2.2.1"
       }
     },
     "webpack-sources": {
@@ -15289,8 +15294,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "requires": {
-        "source-list-map": "~0.1.7",
-        "source-map": "~0.5.3"
+        "source-list-map": "0.1.8",
+        "source-map": "0.5.7"
       }
     },
     "webpack-stats-plugin": {
@@ -15307,8 +15312,8 @@
         "chalk": "1.1.3",
         "commander": "2.9.0",
         "common-tags": "0.1.1",
-        "cross-env": "^3.1.1",
-        "find-node-modules": "^1.0.1",
+        "cross-env": "3.2.4",
+        "find-node-modules": "1.0.4",
         "joi": "9.0.0-0",
         "lodash": "4.11.1",
         "npmlog": "2.0.3",
@@ -15326,7 +15331,7 @@
           "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-0.1.1.tgz",
           "integrity": "sha1-2JNIbsxt8iz/5sOTyIwS9x5+iHE=",
           "requires": {
-            "babel-runtime": "^6.6.1"
+            "babel-runtime": "6.26.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -15334,7 +15339,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isemail": {
@@ -15347,11 +15352,11 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.0-0.tgz",
           "integrity": "sha1-p8pCGWAhSa4Np6fFyh1j08eeCWs=",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "moment": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "moment": "2.22.0",
+            "topo": "2.0.2"
           }
         },
         "load-json-file": {
@@ -15359,11 +15364,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "lodash": {
@@ -15376,7 +15381,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "path-type": {
@@ -15384,9 +15389,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -15399,9 +15404,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -15409,8 +15414,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "set-blocking": {
@@ -15423,9 +15428,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -15433,7 +15438,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "window-size": {
@@ -15446,19 +15451,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
           "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.2",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -15466,8 +15471,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -15477,8 +15482,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.11",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -15507,7 +15512,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -15525,7 +15530,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "2.1.1"
       }
     },
     "widest-line": {
@@ -15533,7 +15538,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
@@ -15551,8 +15556,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -15560,7 +15565,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -15568,9 +15573,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -15586,7 +15591,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -15594,9 +15599,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -15604,8 +15609,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
       "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
       "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
+        "safe-buffer": "5.0.1",
+        "ultron": "1.1.1"
       },
       "dependencies": {
         "safe-buffer": {
@@ -15635,10 +15640,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xml-parse-from-string": {
@@ -15651,8 +15656,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -15685,7 +15690,7 @@
       "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.4.0.tgz",
       "integrity": "sha1-Sq5EfRPBqnOpidiipTCbCxo8o1M=",
       "requires": {
-        "js-yaml": "^3.5.2"
+        "js-yaml": "3.7.0"
       }
     },
     "yargs": {
@@ -15693,19 +15698,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
       }
     },
     "yargs-parser": {
@@ -15713,7 +15718,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
@@ -15721,7 +15726,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {
@@ -15734,22 +15739,22 @@
       "resolved": "https://registry.npmjs.org/yurnalist/-/yurnalist-0.2.1.tgz",
       "integrity": "sha1-LTK5YYq2SRiRwTG9kKUpXhn9S60=",
       "requires": {
-        "chalk": "^1.1.1",
-        "death": "^1.0.0",
-        "debug": "^2.2.0",
-        "detect-indent": "^5.0.0",
-        "inquirer": "^3.0.1",
-        "invariant": "^2.2.0",
-        "is-builtin-module": "^1.0.0",
-        "is-ci": "^1.0.10",
-        "leven": "^2.0.0",
-        "loud-rejection": "^1.2.0",
-        "node-emoji": "^1.0.4",
-        "object-path": "^0.11.2",
-        "read": "^1.0.7",
-        "rimraf": "^2.5.0",
-        "semver": "^5.1.0",
-        "strip-bom": "^3.0.0"
+        "chalk": "1.1.3",
+        "death": "1.1.0",
+        "debug": "2.6.9",
+        "detect-indent": "5.0.0",
+        "inquirer": "3.3.0",
+        "invariant": "2.2.4",
+        "is-builtin-module": "1.0.0",
+        "is-ci": "1.1.0",
+        "leven": "2.1.0",
+        "loud-rejection": "1.6.0",
+        "node-emoji": "1.8.1",
+        "object-path": "0.11.4",
+        "read": "1.0.7",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "detect-indent": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gatsby-plugin-manifest": "^1.0.25",
     "gatsby-plugin-offline": "^1.0.18",
     "gatsby-plugin-react-helmet": "^2.0.10",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-twitter": "^1.0.20",
     "gatsby-source-filesystem": "^1.5.38",
     "gatsby-transformer-remark": "^1.7.41",


### PR DESCRIPTION
According to https://github.com/NekR/self-destroying-sw/tree/master/packages/gatsby-plugin-remove-serviceworker and https://github.com/gatsbyjs/gatsby/issues/2880 this should fully remove the old caching service worker